### PR TITLE
Adds microscope code flattener pattern

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3.3",
+        "imanghafoori/laravel-microscope": "^1.0",
         "krayin/krayin-package-generator": "dev-master"
     },
     "config": {

--- a/config/microscope.php
+++ b/config/microscope.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+    /**
+     * Will disable microscope if set to false.
+     */
+    'is_enabled' => env('MICROSCOPE_ENABLED', true),
+
+    /**
+     * Avoids auto-fix if is set to true.
+     */
+    'no_fix' => false,
+
+    /**
+     * An array of patterns relative to base_path that should be ignored when reporting.
+     */
+    'ignore' => [
+        // 'nova*'
+    ],
+
+    /**
+     * You can turn off the extra variable passing detection, which performs some logs.
+     */
+    'log_unused_view_vars' => true,
+
+    /**
+     * An array of root namespaces to be ignored while scanning for errors.
+     */
+    'ignored_namespaces' => [
+        // 'Laravel\\Nova\\',
+        // 'Laravel\\Nova\\Tests\\'
+    ],
+
+    /**
+     * By default, we only process the first 2000 characters of a file to find the "class" keyword.
+     * So, if you have a lot of use statements or very big docblocks for your classes so that
+     * the "class" falls deep down, you may increase this value, so that it searches deeper.
+     */
+    'class_search_buffer' => 2500,
+
+    /**
+     * The doc blocks in your controllers are generated based on this template.
+     * You can change this template to customize the check:action_comments results.
+     */
+    'action_comment_template' => 'microscope_package::action_comment',
+
+    /**
+     * If a non-default route file is not being scanned,
+     * you can manually add its path here, as below:.
+     */
+    'additional_route_files' => [
+        // app()->basePath('some_folder/my_route.php''),
+    ],
+];

--- a/search_replace.php
+++ b/search_replace.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    "remove_else_1" => [
+        'search' =>
+        "if ('<1:in_between>') {
+            '<2:var>' = '<3:statement>';
+        } else {'<4:in_between>'}
+
+        return '<5:var>';",
+        'replace' => "if ('<1>') {
+            return '<3>';
+        }
+        '<4>'
+
+        return '<5>';",
+        'predicate' => function($matches) {
+            $values = $matches['values'];
+
+            if ($values[1][1] !== $values[4][1]) {
+                return false;
+            }
+
+            return strlen(str_replace(' ', '', $values[3][1])) > 30;
+        },
+        'tags' => ['flatten']
+    ],
+];


### PR DESCRIPTION
You can have laravel-microscope as an automation tool in order to discover wrong imports or namespaces of the classes. it also allows you to define your own code conventions.

To see the pattern in action you have run:
```php artisan search_replace --tag=flatten```
also
```php artisan check:early_return``` and ```php artisan check:all```
would be useful. 

I hope it helps.