### PR TITLE
Removed Active From This Month

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Activity/ActivityDataGrid.php
@@ -247,7 +247,7 @@ class ActivityDataGrid extends DataGrid
                     'key'       => 'this_week',
                 ], [
                     'name'      => 'admin::app.datagrid.filters.this-month',
-                    'isActive'  => true,
+                    'isActive'  => false,
                     'key'       => 'this_month',
                 ], [
                     'name'      => 'admin::app.datagrid.filters.custom',


### PR DESCRIPTION
## Issue Reference
Link: https://github.com/krayin/laravel-crm/issues/407

## Info
- Already one tab filter is by default selected i.e. `All`.
- So removed active from the `This Month`.