### PR TITLE
disallow user to delete current user

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Setting/UserController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Setting/UserController.php
@@ -257,7 +257,7 @@ class UserController extends Controller
 
         $currentUserId = auth()->guard('user')->user()->id;
 
-        if ($index = array_search($currentUserId, $data['rows'])) {
+        if (($index = array_search($currentUserId, $data['rows'])) !== false) {
             unset($data['rows'][$index]);
         }
 


### PR DESCRIPTION
**BUGS:**

 - user is able to delete the current user with the help of mass action.
 - when array_search is finding the current user's id at index 0 and it is being treated as false in if statement.