### PR TITLE
After Creation of Lead its redirected to same pipleline #692 fixed

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -166,12 +166,10 @@ class LeadController extends Controller
         Event::dispatch('lead.create.after', $lead);
 
         session()->flash('success', trans('admin::app.leads.create-success'));
-        if($data['lead_pipeline_id'])
-        {
+        if($data['lead_pipeline_id']) {
             return redirect()->route('admin.leads.index',$data['lead_pipeline_id']);
         }
-        else
-        {
+        else {
             return redirect()->route('admin.leads.index');
         }  
     }

--- a/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Lead/LeadController.php
@@ -166,8 +166,14 @@ class LeadController extends Controller
         Event::dispatch('lead.create.after', $lead);
 
         session()->flash('success', trans('admin::app.leads.create-success'));
-
-        return redirect()->route('admin.leads.index');
+        if($data['lead_pipeline_id'])
+        {
+            return redirect()->route('admin.leads.index',$data['lead_pipeline_id']);
+        }
+        else
+        {
+            return redirect()->route('admin.leads.index');
+        }  
     }
 
     /**


### PR DESCRIPTION
The page should be redirected to the leads of the same pipeline. Issue e #692 Fixed

**BUGS:**

>Otherwise please mention issue #id and use a comma if your PR
#692 

> Describe that thing in a very short line, the word limit is 200.
I have update #692 issue, when user create lead by selecting specific pipeline then After Successful creation pipeline, it redirected to the same pipeline which user selected while creating it
