### PR TITLE
Add `htmlspecialchars` function for nameTag

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Setting/TagDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Setting/TagDataGrid.php
@@ -91,7 +91,7 @@ class TagDataGrid extends DataGrid
                 $html = '<span style="background: ' . ($row->color ?? '#546E7A') . ';width: 15px;height: 15px;margin-top: 3px;border-radius: 50%;float: left;margin-right: 10px;box-shadow: 0px 4px 15.36px 0.75px rgb(0 0 0 / 10%), 0px 2px 6px 0px rgb(0 0 0 / 15%);"></span>';
 
 
-                return $html . $row->name;
+                return $html . htmlspecialchars($row->name);
             },
         ]);
 


### PR DESCRIPTION
**BUGS:**

Fix bug stored XSS in Tags
Disclosure: https://huntr.dev/bounties/a11bca75-f8a8-449d-82cd-d463bfd84f72

The nameTag value is retrieved and used without any filter to prevent XSS execution. PHP provides a built-in `htmlspecialchars` function to do just that. [https://www.php.net/manual/en/function.htmlspecialchars.php](https://www.php.net/manual/en/function.htmlspecialchars.php)

### Before Fix : 
<img width="939" alt="image" src="https://user-images.githubusercontent.com/31820707/143814393-eb9bb775-d8fb-42f7-b784-5987fb847ece.png">

### After Fix : 
<img width="939" alt="image" src="https://user-images.githubusercontent.com/31820707/143814465-73727a83-7e82-4722-8d1b-b3435555c21f.png">

