### PR TITLE
"Note" option added to activities edit page

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/activities/edit.blade.php
@@ -71,6 +71,10 @@
                                     data-vv-as="&quot;{{ __('admin::app.activities.type') }}&quot;"
                                 >
                                     <option value=""></option>
+                                   
+                                   <option value="note" {{ $selectedOption == 'note' ? 'selected' : '' }}>
+                                        {{ __('admin::app.activities.note') }}
+                                    </option>
 
                                     <option value="call" {{ $selectedOption == 'call' ? 'selected' : '' }}>
                                         {{ __('admin::app.activities.call') }}


### PR DESCRIPTION
"Note" option has to be add in the list of options of the activities edit page also because the "Note" function act as a special kind of activities that can be created from the lead_view page.

**BUGS:**

>Please describe the issue that you solved if it's not filed.

>Otherwise please mention issue #id and use a comma if your PR
>solves multiple issues.

The bug is that you can't edit a note.

**For things other than bugs:**

> Describe that thing in a very short line, the word limit is 200.
> Otherwise use **issue #id** if the issue was filed as **feature** request.