### PR TITLE
bugfix for issue #1207

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -244,6 +244,18 @@
                                 }
                             })
 
+			// Remove duplicates from list of leads sent to kanban
+                            if (self.leads) {
+                                let uniqueLeads = self.leads.reduce((unique, obj) => {
+                                    // Check if the object id already exists in the unique array
+                                    if (!unique.some(item => item.id === obj.id)) {
+                                        unique.push(obj);
+                                    }
+                                    return unique;
+                                }, []);
+                                self.leads = uniqueLeads;
+                            }
+
                             this.totalCounts = totalCounts;
 
                             setTimeout(() => {


### PR DESCRIPTION
**BUGS:**

>Please describe the issue that you solved if it's not filed.
> In the leads page if I click on filters and use any of the available ones or click the "Remove all" button it will create a duplicate in the leads but once it's refreshed it disappears.
> Also Scroll is not working in leads stage section.

[#1207 Duplicate leads on Kanban page when filtering](https://github.com/krayin/laravel-crm/issues/1207)

>Otherwise please mention issue #id and use a comma if your PR
>solves multiple issues.

Console errors about duplicate kanban elements have been squashed too.
<img width="1512" alt="Screenshot 2023-10-26 at 9 06 06 PM" src="https://github.com/krayin/laravel-crm/assets/17808066/a2501491-32f3-4742-b974-52f5d29bc04d">
