### PR TITLE
fill filtered date field value after page refresh

### DIFF
--- a/packages/Webkul/UI/src/Resources/assets/js/components/date-range-basic.vue
+++ b/packages/Webkul/UI/src/Resources/assets/js/components/date-range-basic.vue
@@ -35,7 +35,8 @@ export default {
                 allowInput: true,
                 altFormat: "Y-m-d",
                 dateFormat: "Y-m-d",
-                weekNumbers: true
+                weekNumbers: true,
+                defaultDate: "",
             },
             startDatePicker: null,
             endDatePicker: null
@@ -52,6 +53,10 @@ export default {
         activateStartDatePicker: function() {
             let self = this;
 
+            if (this.startDate) {
+                this.config.defaultDate = this.startDate
+            }
+
             this.startDatePicker = new Flatpickr(this.$refs.startDate, {
                 ...this.config,
                 onChange: function(selectedDates, dateStr, instance) {
@@ -66,6 +71,10 @@ export default {
 
         activateEndDatePicker: function() {
             let self = this;
+
+            if (this.endDate) {
+                this.config.defaultDate = this.endDate
+            }
 
             this.endDatePicker = new Flatpickr(this.$refs.endDate, {
                 ...this.config,


### PR DESCRIPTION
issue #1242 (Quotes Date Field Filter Values)

## How to solve it

The reason why date field values are empty is because of not updating the plugin config option called **defaultDate** after page refresh. Date field is using [flatpickr](https://github.com/flatpickr/flatpickr) library and you can read the library config [options](https://flatpickr.js.org/options/) here for reference.