### PR TITLE
fill filtered created date field value after page refresh

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -140,6 +140,18 @@
                 }
             },
 
+            created: function () {
+                let search = window.location.search;
+
+                if (search) {
+                    let params = new URLSearchParams(search)
+
+                    if (params.get('created_at[bw]')) {
+                        this.columns.created_at.values = params.get('created_at[bw]').split(',')
+                    }
+                }
+            },
+
             mounted: function () {
                 EventBus.$on('updateFilter', data => {
                     EventBus.$emit('updateKanbanFilter', data);
@@ -184,7 +196,9 @@
             },
 
             created: function () {
-                this.getLeads();
+                let search = window.location.search;
+
+                this.getLeads(false, search);
 
                 queueMicrotask(() => {
                     $('#search-field').on('search keyup', ({target}) => {
@@ -230,6 +244,8 @@
                             var totalCounts = {};
 
                             var self = this;
+
+                            this.updatedURI(filterValues);
 
                             this.stages.forEach(function(stage) {
                                 if (response.data[stage.id] !== undefined) {
@@ -303,7 +319,16 @@
                             `)
                         }
                     });
-                }
+                },
+
+                updatedURI: function(params) {
+                    let newURL =
+                        window.location.origin +
+                        window.location.pathname +
+                        `${params != "" ? params : ""}`;
+
+                    window.history.pushState({ path: newURL }, "", newURL);
+                },
             }
         });
     </script>

--- a/packages/Webkul/UI/src/Resources/assets/js/components/date-range-basic.vue
+++ b/packages/Webkul/UI/src/Resources/assets/js/components/date-range-basic.vue
@@ -35,7 +35,8 @@ export default {
                 allowInput: true,
                 altFormat: "Y-m-d",
                 dateFormat: "Y-m-d",
-                weekNumbers: true
+                weekNumbers: true,
+                defaultDate: "",
             },
             startDatePicker: null,
             endDatePicker: null
@@ -52,6 +53,10 @@ export default {
         activateStartDatePicker: function() {
             let self = this;
 
+            if (this.startDate) {
+                this.config.defaultDate = this.startDate
+            }
+
             this.startDatePicker = new Flatpickr(this.$refs.startDate, {
                 ...this.config,
                 onChange: function(selectedDates, dateStr, instance) {
@@ -66,6 +71,10 @@ export default {
 
         activateEndDatePicker: function() {
             let self = this;
+
+            if (this.endDate) {
+                this.config.defaultDate = this.endDate
+            }
 
             this.endDatePicker = new Flatpickr(this.$refs.endDate, {
                 ...this.config,


### PR DESCRIPTION
issue #1242 

## How to solve it
This is a quick fix, and I assumed that there is only one filter field called **Created Date** in the current situation. If there are more filter fields like the data grid table in the future, I think the best solution might be to control the filter column from the backend and include it in the response. 

Currently, columns are controlled in the kanban.blade.php file.

The response format from data grid table.
```
{
    "records": {
        "data": [
            {},
            {}
        ]
    },
    "columns": [
        {
            "index": "created_at",
            "label": "Created Date",
            "type": "date_range",
            "sortable": true,
            "filterable": true,
            "values": ["", ""]
        },
        {}
    ],
}
```