### PR TITLE
This PR updates the query in the user repository to include a get() method, ensuring the query results are fetched in AttributeRepository.php

### DIFF
--- a/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
@@ -133,7 +133,7 @@ class AttributeRepository extends Repository
                     ->where('users.name', 'like', '%'.urldecode($query).'%')
                     ->get();
             } elseif ($currentUser->view_permission === 'individual') {
-                return $userRepository->where('users.id', $currentUser->id);
+                return $userRepository->where('users.id', $currentUser->id)->get();
             }
 
             return $userRepository->where('users.name', 'like', '%'.urldecode($query).'%')->get();


### PR DESCRIPTION
Modified the query for users with 'individual' view permission to include the 'get()' method. This ensures the query returns the result as expected. This fixes the issue with users with permission individual to see options in dropdown while creating leads preventing potential issues with missing results.

**BUGS:**

> No options in drop down for create leads sections for user with individual permission.
![image](https://github.com/user-attachments/assets/6ac61b1d-1ce4-46d1-8d33-afa7e7cf62e0)