### PR TITLE
feat: Update boot method to force HTTPS in production environment

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if (config('app.env') === 'production') {
+            \URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
feat: Update boot method to force HTTPS in production

- Added condition to check if the app is in production environment.
- Applied \URL::forceScheme('https') to ensure all URLs are loaded over HTTPS.
- Fixes issue of mixed content where static assets are loaded over HTTP while the page is served over HTTPS.

**BUGS:**

> Fixed mixed content error where static assets were being loaded over HTTP in production.

**For things other than bugs:**

> Updated boot method to ensure all URLs are served over HTTPS in production.
