### PR TITLE
Bug Fix: Prevent Count Error in tln_skipspace Method

### DIFF
--- a/packages/Webkul/Email/src/Helpers/Htmlfilter.php
+++ b/packages/Webkul/Email/src/Helpers/Htmlfilter.php
@@ -56,7 +56,7 @@ class Htmlfilter
         preg_match('/^(\s*)/s', substr($body, $offset), $matches);
 
         try {
-            if (!empty($matches[1])) {
+            if (! empty($matches[1])) {
                 $count = strlen($matches[1]);
                 $offset += $count;
             }

--- a/packages/Webkul/Email/src/Helpers/Htmlfilter.php
+++ b/packages/Webkul/Email/src/Helpers/Htmlfilter.php
@@ -56,7 +56,7 @@ class Htmlfilter
         preg_match('/^(\s*)/s', substr($body, $offset), $matches);
 
         try {
-            if (count($matches[1])) {
+            if (!empty($matches[1])) {
                 $count = strlen($matches[1]);
                 $offset += $count;
             }


### PR DESCRIPTION
#### Description
Fixed a potential type error when checking for whitespace in email parsing.

#### Details
- Modified `tln_skipspace` method to handle string inputs safely
- Prevents "count() must be of type Countable|array" error
- Maintains original logic of skipping whitespace

#### Code Change
```php
// Before
if (count($matches[1])) {
    $count = strlen($matches[1]);
    $offset += $count;
}

// After
if (!empty($matches[1])) {
    $count = strlen($matches[1]);
    $offset += $count;
}
```

### Rationale

- Original code assumed $matches[1] would always be an array
- New implementation checks for non-empty value before processing
- Improves error handling and type safety