### PR TITLE
issue #1992 fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,13 +82,15 @@
             "Tests\\": "tests/"
         }
     },
-    "repositories": [{
-        "type": "path",
-        "url": "packages/*/*",
-        "options": {
-            "symlink": true
+    "repositories": [
+        {
+            "type": "path",
+            "url": "packages/*/*",
+            "options": {
+                "symlink": true
+            }
         }
-    }],
+    ],
     "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -11548,5 +11548,5 @@
         "php": "^8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/packages/Webkul/Automation/src/Helpers/Entity/Lead.php
+++ b/packages/Webkul/Automation/src/Helpers/Entity/Lead.php
@@ -54,7 +54,7 @@ class Lead extends AbstractEntity
      */
     public function getAttributes(string $entityType, array $skipAttributes = ['textarea', 'image', 'file', 'address']): array
     {
-        return parent::getAttributes($entityType, $skipAttributes);
+       return parent::getAttributes($entityType, $skipAttributes);
     }
 
     /**
@@ -71,31 +71,25 @@ class Lead extends AbstractEntity
                 'id'         => 'update_lead',
                 'name'       => trans('admin::app.settings.workflows.helpers.update-lead'),
                 'attributes' => $this->getAttributes('leads'),
-            ],
-            [
+            ], [
                 'id'         => 'update_person',
                 'name'       => trans('admin::app.settings.workflows.helpers.update-person'),
                 'attributes' => $this->getAttributes('persons'),
-            ],
-            [
+            ], [
                 'id'      => 'send_email_to_person',
                 'name'    => trans('admin::app.settings.workflows.helpers.send-email-to-person'),
                 'options' => $emailTemplates,
-            ],
-            [
+            ], [
                 'id'      => 'send_email_to_sales_owner',
                 'name'    => trans('admin::app.settings.workflows.helpers.send-email-to-sales-owner'),
                 'options' => $emailTemplates,
-            ],
-            [
+            ], [
                 'id'   => 'add_tag',
                 'name' => trans('admin::app.settings.workflows.helpers.add-tag'),
-            ],
-            [
+            ], [
                 'id'   => 'add_note_as_activity',
                 'name' => trans('admin::app.settings.workflows.helpers.add-note-as-activity'),
-            ],
-            [
+            ], [
                 'id'      => 'trigger_webhook',
                 'name'    => trans('admin::app.settings.workflows.helpers.add-webhook'),
                 'options' => $webhooksOptions,

--- a/packages/Webkul/Automation/src/Helpers/Entity/Lead.php
+++ b/packages/Webkul/Automation/src/Helpers/Entity/Lead.php
@@ -54,7 +54,7 @@ class Lead extends AbstractEntity
      */
     public function getAttributes(string $entityType, array $skipAttributes = ['textarea', 'image', 'file', 'address']): array
     {
-       return parent::getAttributes($entityType, $skipAttributes);
+        return parent::getAttributes($entityType, $skipAttributes);
     }
 
     /**

--- a/packages/Webkul/Automation/src/Helpers/Entity/Lead.php
+++ b/packages/Webkul/Automation/src/Helpers/Entity/Lead.php
@@ -54,18 +54,7 @@ class Lead extends AbstractEntity
      */
     public function getAttributes(string $entityType, array $skipAttributes = ['textarea', 'image', 'file', 'address']): array
     {
-        $attributes[] = [
-            'id'          => 'lead_pipeline_stage_id',
-            'type'        => 'select',
-            'name'        => 'Stage',
-            'lookup_type' => 'lead_pipeline_stages',
-            'options'     => collect(),
-        ];
-
-        return array_merge(
-            parent::getAttributes($entityType, $skipAttributes),
-            $attributes
-        );
+        return parent::getAttributes($entityType, $skipAttributes);
     }
 
     /**
@@ -82,25 +71,31 @@ class Lead extends AbstractEntity
                 'id'         => 'update_lead',
                 'name'       => trans('admin::app.settings.workflows.helpers.update-lead'),
                 'attributes' => $this->getAttributes('leads'),
-            ], [
+            ],
+            [
                 'id'         => 'update_person',
                 'name'       => trans('admin::app.settings.workflows.helpers.update-person'),
                 'attributes' => $this->getAttributes('persons'),
-            ], [
+            ],
+            [
                 'id'      => 'send_email_to_person',
                 'name'    => trans('admin::app.settings.workflows.helpers.send-email-to-person'),
                 'options' => $emailTemplates,
-            ], [
+            ],
+            [
                 'id'      => 'send_email_to_sales_owner',
                 'name'    => trans('admin::app.settings.workflows.helpers.send-email-to-sales-owner'),
                 'options' => $emailTemplates,
-            ], [
+            ],
+            [
                 'id'   => 'add_tag',
                 'name' => trans('admin::app.settings.workflows.helpers.add-tag'),
-            ], [
+            ],
+            [
                 'id'   => 'add_note_as_activity',
                 'name' => trans('admin::app.settings.workflows.helpers.add-note-as-activity'),
-            ], [
+            ],
+            [
                 'id'      => 'trigger_webhook',
                 'name'    => trans('admin::app.settings.workflows.helpers.add-webhook'),
                 'options' => $webhooksOptions,


### PR DESCRIPTION
## Issue Reference
#1992

## Description
Fix: Removed duplicate "Stage" options when selecting "Lead" in new workflow.

## How To Test This?
1. Go to Workflows and create a new workflow.
2. In the "Conditions" section, select Lead as the entity.
3. Check the dropdown for condition fields.
4. Now the Stage field is not listed twice.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: 2.1