### PR TITLE
Overlay Name and Organization fields on Person View Page #1916

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/form/control-group/controls/inline/lookup.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/form/control-group/controls/inline/lookup.blade.php
@@ -235,6 +235,8 @@
                     dropdownPosition: "bottom",
 
                     isRTL: document.documentElement.dir === 'rtl',
+
+                    uniqueId: Math.floor(100000 + Math.random() * 900000),
                 };
             },
 
@@ -255,6 +257,16 @@
 
             mounted() {
                 window.addEventListener("resize", this.setDropdownPosition);
+
+                this.$emitter.on('lookup-dropdown-opened', (data) => {
+                    if (data.componentId !== this.uniqueId) {
+                        this.showPopup = false;
+                    }
+                });
+            },
+
+            beforeUnmount() {
+                this.$emitter.off('lookup-dropdown-opened');
             },
 
             computed: {
@@ -295,6 +307,8 @@
                 },
 
                 toggleEditor() {
+                    this.$emitter.emit('lookup-dropdown-opened', { componentId: this.uniqueId });
+
                     this.showPopup = ! this.showPopup;
 
                     if (this.showPopup) {
@@ -331,7 +345,7 @@
                             })
                             .catch((error) => {
                                 this.isDirty = false;
-                                
+
                                 this.inputValue = this.value;
 
                                 this.$emitter.emit('add-flash', { type: 'error', message: error.response.data.message });

--- a/packages/Webkul/Admin/src/Resources/views/components/form/control-group/controls/inline/lookup.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/form/control-group/controls/inline/lookup.blade.php
@@ -235,8 +235,6 @@
                     dropdownPosition: "bottom",
 
                     isRTL: document.documentElement.dir === 'rtl',
-
-                    uniqueId: Math.floor(100000 + Math.random() * 900000),
                 };
             },
 
@@ -258,15 +256,7 @@
             mounted() {
                 window.addEventListener("resize", this.setDropdownPosition);
 
-                this.$emitter.on('lookup-dropdown-opened', (data) => {
-                    if (data.componentId !== this.uniqueId) {
-                        this.showPopup = false;
-                    }
-                });
-            },
-
-            beforeUnmount() {
-                this.$emitter.off('lookup-dropdown-opened');
+                this.$emitter.on('show-pop', this.handleShowPop);
             },
 
             computed: {
@@ -307,12 +297,16 @@
                 },
 
                 toggleEditor() {
-                    this.$emitter.emit('lookup-dropdown-opened', { componentId: this.uniqueId });
+                    this.$emitter.emit('show-pop', this.$.uid);
+                },
 
-                    this.showPopup = ! this.showPopup;
+                handleShowPop(uid) {
+                    this.showPopup = (uid === this.$.uid);
 
                     if (this.showPopup) {
-                        this.$nextTick(() => this.$refs.searchInput.focus());
+                        this.$nextTick(() => this.$refs.searchInput?.focus());
+                    } else {
+                        this.isEditing = false;
                     }
                 },
 


### PR DESCRIPTION
## Issue Reference
#1916

## Description
The Name and Organization fields will function smoothly:
- When the Name field popup opens, the Organization field popup will automatically close.
- Likewise, when the Organization field popup opens, the Name field popup will automatically close.

## How To Test This?
- Navigate to the Person View Page.
- Click on the Name field to open its popup.
- Verify that the Organization field popup closes automatically (if open).
- Click on the Organization field to open its popup.
- Ensure that the Name field popup closes automatically (if open).
- Repeat the above steps multiple times to confirm consistent behavior.
- Check that both fields display correctly without any overlapping or improper content rendering.

## Branch Selection
- [ ] Target Branch: 2.1