### PR TITLE
Bugfix/remove time expired quote col 2168

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Quote/QuoteDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Quote/QuoteDataGrid.php
@@ -83,15 +83,6 @@ class QuoteDataGrid extends DataGrid
                 ],
             ],
         ]);
-
-        $this->addColumn([
-            'index'      => 'expired_quotes',
-            'label'      => trans('admin::app.quotes.index.datagrid.expired-quotes'),
-            'type'       => 'date',
-            'searchable' => false,
-            'filterable' => true,
-        ]);
-
         $this->addColumn([
             'index'              => 'person_name',
             'label'              => trans('admin::app.quotes.index.datagrid.person'),

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/index.blade.php
@@ -21,7 +21,7 @@
                 <div class="flex items-center gap-x-2.5">
                     {!! view_render_event('admin.persons.index.create_button.before') !!}
 
-                    @if (bouncer()->hasPermission('admin.contacts.persons.view'))
+                    @if (bouncer()->hasPermission('contacts.persons.create'))
                         <a
                             href="{{ route('admin.contacts.persons.create') }}"
                             class="primary-button"

--- a/packages/Webkul/Admin/src/Resources/views/contacts/persons/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/contacts/persons/index.blade.php
@@ -21,7 +21,7 @@
                 <div class="flex items-center gap-x-2.5">
                     {!! view_render_event('admin.persons.index.create_button.before') !!}
 
-                    @if (bouncer()->hasPermission('contacts.persons.create'))
+                    @if (bouncer()->hasPermission('admin.contacts.persons.view'))
                         <a
                             href="{{ route('admin.contacts.persons.create') }}"
                             class="primary-button"


### PR DESCRIPTION
## Issue Reference
2168

## Description
Removed the redundant "Expired Quote" column from the Quotes table. Both "Expired Quote" and "Expired At" were displaying the same date, making the UI unnecessarily repetitive.

## How To Test This?
Manually verify in Krayin CRM by navigating to Sales → Quotes and ensuring the "Expired Quote" column is removed from the table without affecting layout, data integrity, or functionality.

## Branch Selection
- [ ] Target Branch: 2.1 

![Screenshot from 2025-05-03 11-15-11](https://github.com/user-attachments/assets/292aa26a-523e-4bab-985a-ab5d6d677a3b)

