### PR TITLE
Fix: Sale Owner dropdown showing empty for Individual users

### DIFF
--- a/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
@@ -137,7 +137,7 @@ class AttributeRepository extends Repository
                     ->when(! empty($query), fn ($queryBuilder) => $queryBuilder->where('users.name', 'like', "%{$query}%"))
                     ->get();
             } elseif ($currentUser?->view_permission === 'individual') {
-                return $userRepository->where('users.id', $currentUser->id);
+                return $userRepository->where('users.id', $currentUser->id)->get();
             }
 
             return $userRepository->where('users.name', 'like', '%'.urldecode($query).'%')->get();


### PR DESCRIPTION
## Description
When user role is set to individual and while creating Lead Sales Owner dropdown was empty, the current individual role user was not showing in dropdown,

## How To Test This?
- A new user is created and assigned the role **"Individual"**.  
- After logging in as that user, a new **Lead** is created.  
- On the Lead creation page, the **"Sale Owner"** dropdown appears empty.  
- Because of this, the **`user_id`** field in the database is stored as **NULL** for the created lead.  
- As a result, the user cannot view the leads they created, since those leads are not linked to their **user ID**.
- The issue occurs in the file **`AttributeRepository.php`**, within the **`getLookUpOptions()`** function.

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

