### PR TITLE
Fix: Add missing translation field for dashboard date picker

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -2027,6 +2027,11 @@ return [
     'dashboard' => [
         'index' => [
             'title'   => 'لوحة القيادة',
+
+            // TODO: Needs translation
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+
             'revenue' => [
                 'lost-revenue' => 'الإيرادات المفقودة',
                 'won-revenue'  => 'الإيرادات المكتسبة',

--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -2026,13 +2026,10 @@ return [
     ],
     'dashboard' => [
         'index' => [
-            'title'   => 'لوحة القيادة',
-
-            // TODO: Needs translation
+            'title'      => 'لوحة القيادة',
             'start-date' => 'Start Date',
             'end-date'   => 'End Date',
-
-            'revenue' => [
+            'revenue'    => [
                 'lost-revenue' => 'الإيرادات المفقودة',
                 'won-revenue'  => 'الإيرادات المكتسبة',
             ],

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -2221,6 +2221,9 @@ return [
         'index' => [
             'title' => 'Dashboard',
 
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+
             'revenue' => [
                 'lost-revenue' => 'Lost Revenue',
                 'won-revenue'  => 'Won Revenue',

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -2027,6 +2027,11 @@ return [
     'dashboard' => [
         'index' => [
             'title'   => 'Tablero',
+            
+            // TODO: Needs translation
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+
             'revenue' => [
                 'lost-revenue' => 'Ingresos Perdidos',
                 'won-revenue'  => 'Ingresos Ganados',

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -2026,13 +2026,10 @@ return [
     ],
     'dashboard' => [
         'index' => [
-            'title'   => 'Tablero',
-            
-            // TODO: Needs translation
+            'title'      => 'Tablero',
             'start-date' => 'Start Date',
             'end-date'   => 'End Date',
-
-            'revenue' => [
+            'revenue'    => [
                 'lost-revenue' => 'Ingresos Perdidos',
                 'won-revenue'  => 'Ingresos Ganados',
             ],

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -2027,6 +2027,11 @@ return [
     'dashboard' => [
         'index' => [
             'title'   => 'داشبورد',
+
+            // TODO: Needs translation
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+            
             'revenue' => [
                 'lost-revenue' => 'درآمد از دست رفته',
                 'won-revenue'  => 'درآمد برنده',

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -2026,13 +2026,10 @@ return [
     ],
     'dashboard' => [
         'index' => [
-            'title'   => 'داشبورد',
-
-            // TODO: Needs translation
+            'title'      => 'داشبورد',
             'start-date' => 'Start Date',
             'end-date'   => 'End Date',
-            
-            'revenue' => [
+            'revenue'    => [
                 'lost-revenue' => 'درآمد از دست رفته',
                 'won-revenue'  => 'درآمد برنده',
             ],

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -2027,6 +2027,11 @@ return [
     'dashboard' => [
         'index' => [
             'title'   => 'Início',
+
+            // TODO: Needs translation
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+            
             'revenue' => [
                 'lost-revenue' => 'Negócios Perdidos',
                 'won-revenue'  => 'Negócios Ganhos',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -2026,13 +2026,10 @@ return [
     ],
     'dashboard' => [
         'index' => [
-            'title'   => 'Início',
-
-            // TODO: Needs translation
+            'title'      => 'Início',
             'start-date' => 'Start Date',
             'end-date'   => 'End Date',
-            
-            'revenue' => [
+            'revenue'    => [
                 'lost-revenue' => 'Negócios Perdidos',
                 'won-revenue'  => 'Negócios Ganhos',
             ],

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -2026,13 +2026,10 @@ return [
     ],
     'dashboard' => [
         'index' => [
-            'title'   => 'Gösterge Paneli',
-
-            // TODO: Needs translation
+            'title'      => 'Gösterge Paneli',
             'start-date' => 'Start Date',
             'end-date'   => 'End Date',
-            
-            'revenue' => [
+            'revenue'    => [
                 'lost-revenue' => 'Kayıp Gelir',
                 'won-revenue'  => 'Kazançlı Gelir',
             ],

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -2027,6 +2027,11 @@ return [
     'dashboard' => [
         'index' => [
             'title'   => 'Gösterge Paneli',
+
+            // TODO: Needs translation
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+            
             'revenue' => [
                 'lost-revenue' => 'Kayıp Gelir',
                 'won-revenue'  => 'Kazançlı Gelir',

--- a/packages/Webkul/Admin/src/Resources/lang/vi/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi/app.php
@@ -2026,13 +2026,10 @@ return [
     ],
     'dashboard' => [
         'index' => [
-            'title'   => 'Bảng Điều Khiển',
-
-            // TODO: Needs translation
+            'title'      => 'Bảng Điều Khiển',
             'start-date' => 'Start Date',
             'end-date'   => 'End Date',
-            
-            'revenue' => [
+            'revenue'    => [
                 'lost-revenue' => 'Doanh Thu Bị Mất',
                 'won-revenue'  => 'Doanh Thu Đã Đạt',
             ],

--- a/packages/Webkul/Admin/src/Resources/lang/vi/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi/app.php
@@ -2027,6 +2027,11 @@ return [
     'dashboard' => [
         'index' => [
             'title'   => 'Bảng Điều Khiển',
+
+            // TODO: Needs translation
+            'start-date' => 'Start Date',
+            'end-date'   => 'End Date',
+            
             'revenue' => [
                 'lost-revenue' => 'Doanh Thu Bị Mất',
                 'won-revenue'  => 'Doanh Thu Đã Đạt',


### PR DESCRIPTION
## Issue Reference
Fixes #2302

## Description
Fixes the placeholder text of from and to date picker in dashboard showing raw translation key instead of proper text.

## Changes
- Added `start-date` and `end-date` translation key to all language files
- Used English text as placeholder for non-English languages

## Testing
- [x] Verified from and to date picker displays correctly
- [x] Checked all language files for consistency

## Screenshot
<img width="1908" height="921" alt="Screenshot_20251113_143206" src="https://github.com/user-attachments/assets/ce1f2c75-5abd-4d48-88ce-5f3557193ac4" />
