### PR TITLE
Fix: Move DataTransfer permission to Automation group in ACL

### DIFF
--- a/packages/Webkul/Admin/src/Config/acl.php
+++ b/packages/Webkul/Admin/src/Config/acl.php
@@ -488,32 +488,32 @@ return [
         'sort'  => 2,
     ],
     [
-        'key'   => 'settings.data_transfer',
+        'key'   => 'settings.automation.data_transfer',
         'name'  => 'admin::app.acl.data-transfer',
         'route' => 'admin.settings.data_transfer.imports.index',
         'sort'  => 10,
     ], [
-        'key'   => 'settings.data_transfer.imports',
+        'key'   => 'settings.automation.data_transfer.imports',
         'name'  => 'admin::app.acl.imports',
         'route' => 'admin.settings.data_transfer.imports.index',
         'sort'  => 1,
     ], [
-        'key'   => 'settings.data_transfer.imports.create',
+        'key'   => 'settings.automation.data_transfer.imports.create',
         'name'  => 'admin::app.acl.create',
         'route' => 'admin.settings.data_transfer.imports.create',
         'sort'  => 1,
     ], [
-        'key'   => 'settings.data_transfer.imports.edit',
+        'key'   => 'settings.automation.data_transfer.imports.edit',
         'name'  => 'admin::app.acl.edit',
         'route' => 'admin.settings.data_transfer.imports.edit',
         'sort'  => 2,
     ], [
-        'key'   => 'settings.data_transfer.imports.delete',
+        'key'   => 'settings.automation.data_transfer.imports.delete',
         'name'  => 'admin::app.acl.delete',
         'route' => 'admin.settings.data_transfer.imports.delete',
         'sort'  => 3,
     ], [
-        'key'   => 'settings.data_transfer.imports.import',
+        'key'   => 'settings.automation.data_transfer.imports.import',
         'name'  => 'admin::app.acl.import',
         'route' => 'admin.settings.data_transfer.imports.imports',
         'sort'  => 4,

--- a/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ImportDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ImportDataGrid.php
@@ -122,7 +122,7 @@ class ImportDataGrid extends DataGrid
      */
     public function prepareActions(): void
     {
-        if (bouncer()->hasPermission('settings.data_transfer.imports.import')) {
+        if (bouncer()->hasPermission('settings.automation.data_transfer.imports.import')) {
             $this->addAction([
                 'index'  => 'import',
                 'icon'   => 'icon-import',
@@ -134,7 +134,7 @@ class ImportDataGrid extends DataGrid
             ]);
         }
 
-        if (bouncer()->hasPermission('settings.data_transfer.imports.edit')) {
+        if (bouncer()->hasPermission('settings.automation.data_transfer.imports.edit')) {
             $this->addAction([
                 'index'  => 'edit',
                 'icon'   => 'icon-edit',
@@ -146,7 +146,7 @@ class ImportDataGrid extends DataGrid
             ]);
         }
 
-        if (bouncer()->hasPermission('settings.data_transfer.imports.delete')) {
+        if (bouncer()->hasPermission('settings.automation.data_transfer.imports.delete')) {
             $this->addAction([
                 'index'  => 'delete',
                 'icon'   => 'icon-delete',

--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/create.blade.php
@@ -32,7 +32,7 @@
                 <div class="flex items-center gap-x-2.5">
                     {!! view_render_event('admin.settings.data_transfers.create.save_button.before') !!}
 
-                    @if (bouncer()->hasPermission('settings.data_transfer.imports.create'))
+                    @if (bouncer()->hasPermission('settings.automation.data_transfer.imports.create'))
                         <!-- Save Button -->
                         <button
                             type="submit"

--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/edit.blade.php
@@ -36,7 +36,7 @@
                 <div class="flex items-center gap-x-2.5">
                     {!! view_render_event('admin.settings.data_transfers.edit.save_button.before') !!}
 
-                    @if (bouncer()->hasPermission('settings.data_transfer.imports.edit'))
+                    @if (bouncer()->hasPermission('settings.automation.data_transfer.imports.edit'))
                         <!-- Save Button -->
                         <button
                             type="submit"

--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/import.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/import.blade.php
@@ -27,7 +27,7 @@
                 {!! view_render_event('admin.settings.data_transfers.import.edit_button.before') !!}
 
                 <!-- Edit Button -->
-                @if (bouncer()->hasPermission('settings.data_transfer.imports.edit'))
+                @if (bouncer()->hasPermission('settings.automation.data_transfer.imports.edit'))
                     <a
                         href="{{ route('admin.settings.data_transfer.imports.edit', $import->id) }}"
                         class="primary-button"

--- a/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/data-transfer/imports/index.blade.php
@@ -23,7 +23,7 @@
                 <div class="flex items-center gap-x-2.5">
                     {!! view_render_event('admin.settings.data_transfers.index.create_button.before') !!}
 
-                    @if (bouncer()->hasPermission('settings.data_transfer.imports.create'))
+                    @if (bouncer()->hasPermission('settings.automation.data_transfer.imports.create'))
                         <a 
                             href="{{ route('admin.settings.data_transfer.imports.create') }}" 
                             class="primary-button"


### PR DESCRIPTION
## Issue Reference
User with DataTransfer permission unable to see DataTransfer option in Settings #2373

This PR fixes an issue where users with the DataTransfer permission could not see the option in the Settings menu.

The Problem: The data_transfer permission group was incorrectly placed in the acl.php configuration file, causing it to be hidden from the UI even when assigned.

The Fix: I have moved the data_transfer permission group under settings -> automation in packages/Webkul/Admin/src/Config/acl.php

## How To Test This?
Steps to Reproduce (Verified)
1. Create a new role and assign it the "DataTransfer" permission.

2. Create a new user and assign this role to them.

3. Log in as the newly created user.

4. Navigate to Settings -> Automation.

5. The DataTransfer option is now visible under automation not as a standalone (which made the module not display on assignment).

Evidence
Before (Issue): https://webkul.chatwhizz.com/share/view-recording/68da82a87f05a00572f6d57f

After: 
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/f09cad09-0f84-4343-8a77-102837bb889d" />
