### PR TITLE
fix: product search unresponsive issue

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Product/ProductDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Product/ProductDataGrid.php
@@ -37,6 +37,9 @@ class ProductDataGrid extends DataGrid
         }
 
         $this->addFilter('id', 'products.id');
+        $this->addFilter('sku', 'products.sku');
+        $this->addFilter('name', 'products.name');
+        $this->addFilter('price', 'products.price');
         $this->addFilter('total_in_stock', DB::raw('SUM('.$tablePrefix.'product_inventories.in_stock'));
         $this->addFilter('total_allocated', DB::raw('SUM('.$tablePrefix.'product_inventories.allocated'));
         $this->addFilter('total_on_hand', DB::raw('SUM('.$tablePrefix.'product_inventories.in_stock - '.$tablePrefix.'product_inventories.allocated'));


### PR DESCRIPTION
## Issue Reference
Fixes #2397

## Description
Add explicit table-qualified filter mappings for products columns to prevent SQL ambiguity error when searching. The 'name' column exists in both products and tags tables, causing "Column 'name' in WHERE is ambiguous" error.

Fixes SQLSTATE[23000] integrity constraint violation during product search.

Now, the DataGrid search functionality can properly distinguish between products.name and tags.name when building WHERE clauses.

## How To Test This?
- Go to `/admin/products`
- Search for any product