### PR TITLE
Fix right panel layout in lead view, when they have Extratypes

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/activities/index.blade.php
@@ -39,8 +39,8 @@
         <template v-else>
             {!! view_render_event('admin.components.activities.content.before') !!}
 
-            <div class="w-full rounded-md border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
-                <div class="flex gap-2 overflow-x-auto border-b border-gray-200 dark:border-gray-800">
+            <div class="rounded-md border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+                <div class="flex flex-wrap gap-2 border-b border-gray-200 dark:border-gray-800">
                     {!! view_render_event('admin.components.activities.content.types.before') !!}
 
                     <div


### PR DESCRIPTION
## Issue Reference
N/A – Issue identified and fixed proactively during manual usage.

## Description
This PR fixes a layout breaking issue on the Lead view when a large number of extra types are present.
Previously, when multiple extra type fields were rendered, the layout overflowed and caused UI misalignment and poor usability.

The view has been adjusted to handle large numbers of extra types gracefully, ensuring the layout remains responsive and visually consistent regardless of the amount of data displayed.

## How To Test This?
1. Go to Leads and open an existing lead.

2. Ensure the lead has multiple extra types (enough to previously break the layout).

3. Verify that:

- The layout does not overflow or break.

- All extra types are displayed correctly.

- The Lead view remains responsive on different screen sizes.

4. Confirm that leads with fewer or no extra types continue to render correctly.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
No documentation changes are required, as this is a UI/layout fix only.

## Branch Selection
- [ x] Target Branch: master 

## Tailwind Reordering
All Tailwind CSS classes were reordered and aligned according to the existing project conventions.