### PR TITLE
Fix global search for Types

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Settings/TypeDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/TypeDataGrid.php
@@ -33,6 +33,7 @@ class TypeDataGrid extends DataGrid
             'index'      => 'id',
             'label'      => trans('admin::app.settings.types.index.datagrid.id'),
             'type'       => 'string',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);
@@ -41,6 +42,7 @@ class TypeDataGrid extends DataGrid
             'index'      => 'name',
             'label'      => trans('admin::app.settings.types.index.datagrid.name'),
             'type'       => 'string',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix Issue #2417 

## Description
<!--- Please describe your changes in detail. -->
This PR enables global search functionality for the Types listing in Settings.
Previously, the top search input did not work for Types because the relevant column was not included in the global search configuration. With this change, searching now works as expected.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Dashboard → Settings → Types
2. Use the top search input
3. Enter a type name
4. Verify that the results are filtered correctly based on the search term

## Documentation
- [x] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
 - [x] Not Applicable