### PR TITLE
Fix global search functionality for Roles

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Settings/RoleDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/RoleDataGrid.php
@@ -36,6 +36,7 @@ class RoleDataGrid extends DataGrid
             'index'      => 'id',
             'label'      => trans('admin::app.settings.roles.index.datagrid.id'),
             'type'       => 'string',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);
@@ -44,6 +45,7 @@ class RoleDataGrid extends DataGrid
             'index'      => 'name',
             'label'      => trans('admin::app.settings.roles.index.datagrid.name'),
             'type'       => 'string',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);
@@ -52,6 +54,7 @@ class RoleDataGrid extends DataGrid
             'index'    => 'description',
             'label'    => trans('admin::app.settings.roles.index.datagrid.description'),
             'type'     => 'string',
+            'searchable' => true,
             'sortable' => false,
         ]);
 

--- a/packages/Webkul/Admin/src/DataGrids/Settings/RoleDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/RoleDataGrid.php
@@ -51,11 +51,11 @@ class RoleDataGrid extends DataGrid
         ]);
 
         $this->addColumn([
-            'index'    => 'description',
-            'label'    => trans('admin::app.settings.roles.index.datagrid.description'),
-            'type'     => 'string',
+            'index'      => 'description',
+            'label'      => trans('admin::app.settings.roles.index.datagrid.description'),
+            'type'       => 'string',
             'searchable' => true,
-            'sortable' => false,
+            'sortable'   => false,
         ]);
 
         $this->addColumn([


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Issue #2415 

## Description
<!--- Please describe your changes in detail. -->
This PR enables global search functionality for the Roles listing in Settings.
Previously, the top search input did not work for Roles because the relevant column was not included in the global search configuration. With this change, searching now works as expected.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Dashboard → Settings → Roles
2. Use the top search input
3. Enter a role name or description
4. Verify that the results are filtered correctly based on the search term

## Documentation
- [x] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
- [x] Not Applicable