### PR TITLE
fix: enable global search for quotes

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Quote/QuoteDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Quote/QuoteDataGrid.php
@@ -65,6 +65,7 @@ class QuoteDataGrid extends DataGrid
             'label'      => trans('admin::app.quotes.index.datagrid.subject'),
             'type'       => 'string',
             'filterable' => true,
+            'searchable' => true,
             'sortable'   => true,
         ]);
 
@@ -73,6 +74,7 @@ class QuoteDataGrid extends DataGrid
             'label'              => trans('admin::app.quotes.index.datagrid.sales-person'),
             'type'               => 'string',
             'sortable'           => true,
+            'searchable'         => true,
             'filterable'         => true,
             'filterable_type'    => 'searchable_dropdown',
             'filterable_options' => [
@@ -89,6 +91,7 @@ class QuoteDataGrid extends DataGrid
             'label'              => trans('admin::app.quotes.index.datagrid.person'),
             'type'               => 'string',
             'sortable'           => true,
+            'searchable'         => true,
             'filterable'         => true,
             'filterable_type'    => 'searchable_dropdown',
             'filterable_options' => [


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
fix #2429
## Description
<!--- Please describe your changes in detail. -->
The global search input on the Quotes listing page was not applying any filtering.
This PR ensures the search value is correctly applied to the Quotes DataGrid query so records are filtered based on the entered term. When no matches are found, an empty result set is shown.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Dashboard → Quotes.
2. Enter any value in the search input and apply the search.
3. Verify that only matching records are displayed.
4. Enter a value that does not match any record.
5. Verify that no records are shown.
6. Clear the search input and confirm all records are visible again.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
- [ ] Tailwind classes are already ordered correctly. 