### PR TITLE
fix: missing translations for lead won/lost modal

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -239,7 +239,7 @@
                         <!-- Header -->
                         <x-slot:header>
                             <h3 class="text-base font-semibold dark:text-white">
-                                @lang('admin::app.leads.index.kanban.stages.need-more-info')
+                                @lang('admin::app.leads.view.stages.need-more-info')
                             </h3>
                         </x-slot>
 
@@ -255,7 +255,7 @@
                             <template v-if="finalized.stage.code == 'won'">
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label>
-                                        @lang('admin::app.leads.index.kanban.stages.won-value')
+                                        @lang('admin::app.leads.view.stages.won-value')
                                     </x-admin::form.control-group.label>
 
                                     <x-admin::form.control-group.control
@@ -270,7 +270,7 @@
                             <template v-else>
                                 <x-admin::form.control-group>
                                     <x-admin::form.control-group.label>
-                                        @lang('admin::app.leads.index.kanban.stages.lost-reason')
+                                        @lang('admin::app.leads.view.stages.lost-reason')
                                     </x-admin::form.control-group.label>
 
                                     <x-admin::form.control-group.control
@@ -283,7 +283,7 @@
                             <!-- Closed At -->
                             <x-admin::form.control-group>
                                 <x-admin::form.control-group.label>
-                                    @lang('admin::app.leads.index.kanban.stages.closed-at')
+                                    @lang('admin::app.leads.view.stages.closed-at')
                                 </x-admin::form.control-group.label>
 
                                 <x-admin::form.control-group.control
@@ -300,7 +300,7 @@
                         <x-slot:footer>
                             <x-admin::button
                                 class="primary-button"
-                                :title="trans('admin::app.leads.index.kanban.stages.save-btn')"
+                                :title="trans('admin::app.leads.view.stages.save-btn')"
                                 ::loading="finalized.updating"
                                 ::disabled="finalized.updating"
                             />


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix #2341 

## Description
<!--- Please describe your changes in detail. -->
Added missing translation keys for the Lead Won/Lost reason modal, ensuring all modal labels and messages are properly localized instead of displaying raw translation keys.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Leads → Kanban view
2. Drag any lead to Won or Lost
3. Verify the reason modal opens
4. Confirm all texts are displayed correctly in:
     - English 
     - Any non-English language (e.g. Arabic, Turkish)

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
No Tailwind class changes made.