### PR TITLE
fix: prevent creating quote without products

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Quote/QuoteController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Quote/QuoteController.php
@@ -62,6 +62,7 @@ class QuoteController extends Controller
      */
     public function store(AttributeForm $request): RedirectResponse
     {
+        $this->additionalValidation();
         Event::dispatch('quote.create.before');
 
         $quote = $this->quoteRepository->create($request->all());
@@ -98,6 +99,7 @@ class QuoteController extends Controller
      */
     public function update(AttributeForm $request, int $id): RedirectResponse
     {
+        $this->additionalValidation();
         Event::dispatch('quote.update.before', $id);
 
         $quote = $this->quoteRepository->update($request->all(), $id);
@@ -194,5 +196,21 @@ class QuoteController extends Controller
             view('admin::quotes.pdf', compact('quote'))->render(),
             'Quote_'.$quote->subject.'_'.$quote->created_at->format('d-m-Y')
         );
+    }
+     /**
+     * Additional validation for quote product items.
+     */
+    private function additionalValidation(): void
+    {
+        $this->validate(request(), [
+            'items'                   => 'required|array',
+            'items.*.product_id'      => 'required|exists:products,id',
+            'items.*.quantity'        => 'required|numeric|min:0',
+            'items.*.price'           => 'required|numeric|min:0',
+            'items.*.total'           => 'required|numeric|min:0',
+            'items.*.discount_amount' => 'required|numeric|min:0',
+            'items.*.tax_amount'      => 'required|numeric|min:0',
+            'items.*.final_total'     => 'required|numeric|min:0',
+        ]);
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Quote/QuoteController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Quote/QuoteController.php
@@ -197,7 +197,8 @@ class QuoteController extends Controller
             'Quote_'.$quote->subject.'_'.$quote->created_at->format('d-m-Y')
         );
     }
-     /**
+
+    /**
      * Additional validation for quote product items.
      */
     private function additionalValidation(): void

--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/date.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/date.blade.php
@@ -6,6 +6,7 @@
             $value = \Carbon\Carbon::parse($value)->format('Y-m-d');
         }
     }
+    $value = old($attribute->code, $value);
 @endphp
 
 <x-admin::form.control-group.control

--- a/packages/Webkul/Admin/src/Resources/views/quotes/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/quotes/create.blade.php
@@ -442,7 +442,13 @@
                             :preload="true"
                             :placeholder="trans('admin::app.quotes.create.search-products')"
                             @on-selected="(product) => addProduct(product)"
+                            rules="required"
+                            :label="trans('admin::app.quotes.create.product-name')"
+                            ::class="errors[`${inputName}[product_id]`] ? 'border !border-red-600 hover:border-red-600' : ''"
                         />
+
+                        <x-admin::form.control-group.error name="items.item_0.product_id"/>
+                        <x-admin::form.control-group.error name="items[item_0][product_id]"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -454,13 +460,14 @@
                             type="inline"
                             ::name="`${inputName}[quantity]`"
                             ::value="product.quantity"
-                            rules="required|decimal:4"
+                            rules="required|numeric|min:1"
                             ::errors="errors"
                             :label="trans('admin::app.quotes.create.quantity')"
                             :placeholder="trans('admin::app.quotes.create.quantity')"
                             @on-change="(event) => product.quantity = event.value"
                             position="center"
                         />
+                        <x-admin::form.control-group.error name="items.item_0.quantity"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -479,6 +486,7 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.price)"
                         />
+                        <x-admin::form.control-group.error name="items.item_0.price"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -497,6 +505,7 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.price * product.quantity)"
                         />
+                        <x-admin::form.control-group.error name="items.item_0.total"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -515,6 +524,7 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.discount_amount)"
                         />
+                        <x-admin::form.control-group.error name="items.item_0.discount_amount"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -533,6 +543,7 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.tax_amount)"
                         />
+                        <x-admin::form.control-group.error name="items.item_0.tax_amount"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -548,6 +559,7 @@
                             position="center"
                             ::value-label="$admin.formatPrice(parseFloat(product.price * product.quantity) + parseFloat(product.tax_amount) - parseFloat(product.discount_amount))"
                         />
+                        <x-admin::form.control-group.error name="items.item_0.final_total"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 

--- a/packages/Webkul/Admin/src/Resources/views/quotes/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/quotes/edit.blade.php
@@ -332,6 +332,7 @@
                             </template>
                         </x-admin::table.tbody>
                     </x-admin::table>
+                    <x-admin::form.control-group.error name="items"/>
                 </div>
 
                 <!-- Add New Quote Item -->
@@ -428,7 +429,12 @@
                             ::value="{ id: product.product_id, name: product.name }"
                             @on-selected="(product) => addProduct(product)"
                             :placeholder="trans('admin::app.quotes.edit.search-products')"
+                            rules="required"
+                            :label="trans('admin::app.quotes.edit.product-name')"
+                            ::class="errors[`${inputName}[product_id]`] ? 'border !border-red-600 hover:border-red-600' : ''"
                         />
+                        <x-admin::form.control-group.error name="`items.${product.id}.product_id`"/>
+                        <x-admin::form.control-group.error ::name="`${inputName}[product_id]`"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -446,6 +452,7 @@
                             @on-change="(event) => product.quantity = event.value"
                             position="center"
                         />
+                        <x-admin::form.control-group.error ::name="`items.${product.id}.quantity`"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -455,7 +462,7 @@
                         <x-admin::form.control-group.control
                             type="inline"
                             ::name="`${inputName}[price]`"
-                            ::value="product.price"
+                            ::value="(product.price) ?? 0"
                             rules="required|decimal:4"
                             ::errors="errors"
                             :label="trans('admin::app.quotes.create.price')"
@@ -464,6 +471,8 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.price)"
                         />
+                        <x-admin::form.control-group.error name="`items.${product.id}.price`"/>
+                        <x-admin::form.control-group.error ::name="`${inputName}[price]`"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -473,7 +482,7 @@
                         <x-admin::form.control-group.control
                             type="inline"
                             ::name="`${inputName}[total]`"
-                            ::value="product.price * product.quantity"
+                            ::value="(product.price * product.quantity) ?? 0"
                             rules="required|decimal:4"
                             ::errors="errors"
                             :label="trans('admin::app.quotes.create.total')"
@@ -482,6 +491,8 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.price * product.quantity)"
                         />
+                        <x-admin::form.control-group.error name="`items.${product.id}.total`"/>
+                        <x-admin::form.control-group.error ::name="`${inputName}[total]`"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 
@@ -500,6 +511,8 @@
                             position="center"
                             ::value-label="$admin.formatPrice(product.discount_amount)"
                         />
+                        <x-admin::form.control-group.error name="`items.${product.id}.discount_amount`"/>
+                        <x-admin::form.control-group.error ::name="`${inputName}[discount_amount]`"/>
                     </x-admin::form.control-group>
                 </x-admin::table.td>
 

--- a/packages/Webkul/Admin/tests/e2e-pw/tests/quotes.spec.ts
+++ b/packages/Webkul/Admin/tests/e2e-pw/tests/quotes.spec.ts
@@ -4,6 +4,7 @@ import {
     createPerson,
     generateDate,
     generateName,
+    createProduct
 } from "../utils/faker";
 
 test.describe("quotes management", () => {
@@ -13,7 +14,11 @@ test.describe("quotes management", () => {
          */
         await adminPage.goto("admin/contacts/persons");
         const Person = await createPerson(adminPage);
-
+        /**
+         * Create Product.
+         */
+        await adminPage.goto("admin/products");
+        const Product = await createProduct(adminPage);
         /**
          * Create quote.
          */
@@ -97,6 +102,14 @@ test.describe("quotes management", () => {
         await adminPage
             .locator('input[name="shipping_address\\[postcode\\]"]')
             .fill("201301");
+
+         await adminPage.locator('.relative.flex.cursor-pointer.items-center.justify-between.rounded.border.p-2').first().click();
+
+        await adminPage.getByRole("textbox", { name: "Search..." }).click();
+        await adminPage.getByRole("textbox", { name: "Search..." }).fill(Product.name);
+
+        await adminPage.getByRole("listitem").filter({ hasText: Product.name }).click();
+
         await adminPage.getByRole("button", { name: "Save Quote" }).click();
         await expect(adminPage.locator("#app")).toContainText("Success");
     });

--- a/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
+++ b/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
@@ -505,6 +505,6 @@ export {
     createOrganization,
     generateCompanyName,
     createPerson,
-    getRandomDateTime
+    getRandomDateTime,
     createProduct
 };

--- a/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
+++ b/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
@@ -468,7 +468,7 @@ async function createProduct(page) {
     await page.getByRole('textbox', { name: 'Name *' }).fill(name);
     await page.getByRole('textbox', { name: 'Description' }).fill(description);
     await page.getByRole('textbox', { name: 'SKU *' }).fill(sku);
-    await page.getByRole('textbox', { name: 'Price *' }).fill(price);
+    await page.getByRole('textbox', { name: /price/i }).fill(price);
     await page.getByRole('textbox', { name: 'Quantity *' }).fill(quantity);
 
     await page.getByRole('button', { name: 'Save Products' }).click();

--- a/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
+++ b/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
@@ -15,16 +15,16 @@ const usedSlugs = new Set();
  */
 function generateName() {
     const adjectives = [
-        "Cool", "Smart", "Fast", "Sleek", "Innovative", "Shiny", "Bold", 
-        "Elegant", "Epic", "Mystic", "Brilliant", "Luminous", "Radiant", 
-        "Majestic", "Vivid", "Glowing", "Dynamic", "Fearless", "Silent", 
+        "Cool", "Smart", "Fast", "Sleek", "Innovative", "Shiny", "Bold",
+        "Elegant", "Epic", "Mystic", "Brilliant", "Luminous", "Radiant",
+        "Majestic", "Vivid", "Glowing", "Dynamic", "Fearless", "Silent",
         "Electric", "Golden", "Blazing", "Timeless", "Noble", "Eternal"
       ];
-      
+
       const nouns = [
-        "Star", "Vision", "Echo", "Spark", "Horizon", "Nova", "Shadow", 
-        "Wave", "Pulse", "Vortex", "Zenith", "Element", "Flare", "Comet", 
-        "Galaxy", "Ember", "Crystal", "Sky", "Stone", "Blaze", "Eclipse", 
+        "Star", "Vision", "Echo", "Spark", "Horizon", "Nova", "Shadow",
+        "Wave", "Pulse", "Vortex", "Zenith", "Element", "Flare", "Comet",
+        "Galaxy", "Ember", "Crystal", "Sky", "Stone", "Blaze", "Eclipse",
         "Storm", "Orbit", "Phantom", "Mirage"
       ];
 
@@ -361,6 +361,23 @@ function generateCompanyName() {
     return `${prefixes[Math.floor(Math.random() * prefixes.length)]} ${suffixes[Math.floor(Math.random() * suffixes.length)]}`;
 }
 
+function generateProductName() {
+    const adjectives = ['Awesome', 'Portable', 'Eco', 'Smart', 'Compact'];
+    const items = ['Phone', 'Laptop', 'Bottle', 'Bag', 'Watch'];
+    return (
+        adjectives[Math.floor(Math.random() * adjectives.length)] +
+        ' ' +
+        items[Math.floor(Math.random() * items.length)]
+    );
+}
+
+function generatePrice() {
+    return (Math.random() * (999 - 10) + 10).toFixed(2);
+}
+
+function generateQuantity() {
+    return Math.floor(Math.random() * 100 + 1).toString();
+}
 /**
  * Function to automate organization creation
  */
@@ -383,14 +400,14 @@ async function createOrganization(page) {
     await page.getByRole('textbox', { name: 'City' }).fill('Delhi');
     await page.getByRole('textbox', { name: 'Postcode' }).fill('123456');
 
-    /** 
+    /**
      * Click to add extra details
      */
     await page.locator('div').filter({ hasText: /^Click to add$/ }).nth(2).click();
     await page.getByRole('textbox', { name: 'Search...' }).fill('exampl');
     await page.getByRole('listitem').filter({ hasText: 'Example' }).click();
 
-    /** 
+    /**
      * Click on "Save Organization"
      */
     await page.getByRole('button', { name: 'Save Organization' }).click();
@@ -438,6 +455,27 @@ async function createPerson(page) {
 
     return { Name, email, phone };
 }
+
+async function createProduct(page) {
+    const name = generateProductName();
+    const description = generateDescription();
+    const sku = generateSKU();
+    const price = generatePrice();
+    const quantity = generateQuantity();
+
+    await page.getByRole('link', { name: 'Create Product' }).click();
+
+    await page.getByRole('textbox', { name: 'Name *' }).fill(name);
+    await page.getByRole('textbox', { name: 'Description' }).fill(description);
+    await page.getByRole('textbox', { name: 'SKU *' }).fill(sku);
+    await page.getByRole('textbox', { name: 'Price *' }).fill(price);
+    await page.getByRole('textbox', { name: 'Quantity *' }).fill(quantity);
+
+    await page.getByRole('button', { name: 'Save Products' }).click();
+
+    return { name };
+}
+
 function getRandomDateTime() {
     const year = Math.floor(Math.random() * (2030 - 2020 + 1)) + 2020;
     const month = String(Math.floor(Math.random() * 12) + 1).padStart(2, '0');
@@ -445,7 +483,7 @@ function getRandomDateTime() {
     const hours = String(Math.floor(Math.random() * 24)).padStart(2, '0');
     const minutes = String(Math.floor(Math.random() * 60)).padStart(2, '0');
     const seconds = String(Math.floor(Math.random() * 60)).padStart(2, '0');
-  
+
     return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
   }
 
@@ -468,4 +506,5 @@ export {
     generateCompanyName,
     createPerson,
     getRandomDateTime
+    createProduct
 };

--- a/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
+++ b/packages/Webkul/Admin/tests/e2e-pw/utils/faker.ts
@@ -470,7 +470,6 @@ async function createProduct(page) {
     await page.getByRole('textbox', { name: 'SKU *' }).fill(sku);
     await page.getByRole('textbox', { name: /price/i }).fill(price);
     await page.getByRole('textbox', { name: 'Quantity *' }).fill(quantity);
-
     await page.getByRole('button', { name: 'Save Products' }).click();
 
     return { name };


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix #2139 

## Description
<!--- Please describe your changes in detail. -->
This pull request prevents creating a quote without selecting any products.
It adds validation to ensure at least one product is present before a quote can be saved, avoiding incomplete or incorrect quotes.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Admin Panel → Quotes → Create Quote.
2. Fill in the required quote details without adding any products.
3. Click Save.
4. Verify that the quote is not created and an error is shown.
5. Add at least one product and save again.
6. Verify that the quote is created successfully.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
- [x] All Tailwind classes are reordered.