### PR TITLE
fix: enable global search functionality for organizations

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Contact/OrganizationDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Contact/OrganizationDataGrid.php
@@ -55,6 +55,7 @@ class OrganizationDataGrid extends DataGrid
             'index'      => 'name',
             'label'      => trans('admin::app.contacts.organizations.index.datagrid.name'),
             'type'       => 'string',
+            'searchable' => true,
             'sortable'   => true,
             'filterable' => true,
         ]);


### PR DESCRIPTION
## Issue Reference
fix #2443 

## Description
<!--- Please describe your changes in detail. -->
This PR enables global search functionality for the Organizations listing
Previously, the top search input did not work for Organizations because the relevant column was not included in the global search configuration. With this change, searching now works as expected.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Dashboard → Contacts → Organizations
2. Use the search input
3. Enter a organization name
4. Verify that the results are filtered correctly based on the search term

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
- [x] Not Applicable