### PR TITLE
fix: normalize phone number and ensure label selection

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
@@ -82,7 +82,7 @@
             @lang("admin::app.common.custom-attributes.add-more")
         </span>
     </script>
-
+    <script src="https://unpkg.com/libphonenumber-js/bundle/libphonenumber-max.js"></script>
     <script type="module">
         app.component('v-phone-component', {
             template: '#v-phone-component-template',
@@ -98,7 +98,12 @@
             watch: {
                 value(newValue, oldValue) {
                     if (JSON.stringify(newValue) !== JSON.stringify(oldValue)) {
-                        this.contactNumbers = newValue || [{'value': '', 'label': 'work'}];
+                        this.contactNumbers = (newValue || [{'value': '', 'label': 'work'}])
+                            .map(contactNumber => ({
+                                ...contactNumber,
+                                value: this.cleanPhone(contactNumber.value),
+                                label: (contactNumber.label || 'work').toLowerCase()
+                            }));
                     }
                 },
             },
@@ -122,6 +127,10 @@
                         'label': 'work'
                     }];
                 }
+                 this.contactNumbers = this.contactNumbers.map(contactNumber => ({
+                    value: this.cleanPhone(contactNumber.value),
+                    label: (contactNumber.label || 'work').toLowerCase()
+                }));
             },
 
             methods: {
@@ -134,6 +143,17 @@
 
                 remove(contactNumber) {
                     this.contactNumbers = this.contactNumbers.filter(number => number !== contactNumber);
+                },
+                cleanPhone(value) {
+                    if (!value) return value;
+
+                    const phone = libphonenumber.parsePhoneNumberFromString(value);
+
+                    if (phone) {
+                        return phone.nationalNumber;
+                    }
+
+                    return value;
                 },
 
                 extendValidations() {

--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
@@ -146,13 +146,10 @@
                 },
                 cleanPhone(value) {
                     if (!value) return value;
-
                     const phone = libphonenumber.parsePhoneNumberFromString(value);
-
                     if (phone) {
                         return phone.nationalNumber;
                     }
-
                     return value;
                 },
 

--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
@@ -127,10 +127,7 @@
                         'label': 'work'
                     }];
                 }
-                 this.contactNumbers = this.contactNumbers.map(contactNumber => ({
-                    value: this.cleanPhone(contactNumber.value),
-                    label: (contactNumber.label || 'work').toLowerCase()
-                }));
+                 
             },
 
             methods: {

--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/edit/phone.blade.php
@@ -150,7 +150,7 @@
                     if (phone) {
                         return phone.nationalNumber;
                     }
-                    return value;
+                    return value.replace(/\D/g, '');
                 },
 
                 extendValidations() {

--- a/packages/Webkul/Admin/tests/e2e-pw/tests/contacts/person.spec.ts
+++ b/packages/Webkul/Admin/tests/e2e-pw/tests/contacts/person.spec.ts
@@ -15,6 +15,7 @@ test("should be able to assign a company to person", async ({ adminPage }) => {
      */
     await adminPage.goto("admin/contacts/persons");
     await createPerson(adminPage);
+    await expect(adminPage.locator("span.icon-edit")).toBeVisible();
     await adminPage.locator("span.icon-edit").first().click();
     await adminPage
         .locator("div")


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
fix #2447 
## Description
<!--- Please describe your changes in detail. -->
Fixes phone number validation issue during manual lead creation when selecting a contact created via MagicAI or file upload.
Phone numbers stored with country code and formatting (e.g. +91-7120966590) were triggering validation errors and causing dropdown label mismatch.
## Changes:

- Normalized phone numbers using `libphonenumber-js` to extract national number.
- Ensured label values are lowercase (`work, home`) for proper dropdown selection.
- Added default fallback to `work` when label is missing.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Create a Contact Person via MagicAI or import with a formatted number (e.g. +91-7120966590).
2. Create a Lead manually.
3. Select the same contact.
4. Verify:
      - Phone number auto-fills correctly. 
      - Dropdown selects correct label.
      - No validation error appears.


## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
- [x] Tailwind classes reordered where applicable.