### PR TITLE
Fix quote description truncation beyond 255 characters

### DIFF
--- a/packages/Webkul/Quote/src/Database/Migrations/2026_02_16_222257_change_description_to_text_in_quotes_table.php
+++ b/packages/Webkul/Quote/src/Database/Migrations/2026_02_16_222257_change_description_to_text_in_quotes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+    }
+
+     /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->string('description')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fixes https://github.com/krayin/laravel-crm/issues/2454

## Description
<!--- Please describe your changes in detail. -->
I resolved an issue where the quote description was being truncated to 255 characters. Previously, if a user entered a longer description, only the first 255 characters were saved without any warning.

To fix this, I created a migration and updated the description column type from string to text, allowing longer content to be stored without truncation.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Quotes.
2. Create a new quote or edit an existing one.
3. Enter a description longer than 255 characters.
4. Save the quote and reopen it.
5. Verify that the full description is saved without truncation.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
Not applicable