### PR TITLE
Fix: Display quote description in PDF and add missing translations

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -423,6 +423,7 @@ return [
                 'subject'          => 'Subject',
                 'tax'              => 'الضريبة',
                 'title'            => 'عرض السعر',
+                'description'      => 'الوصف',
             ],
         ],
         'create' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -472,6 +472,7 @@ return [
                 'subject'          => 'Subject',
                 'tax'              => 'Tax',
                 'title'            => 'Quote',
+                'description'      => 'Description',
             ],
         ],
 

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -423,6 +423,7 @@ return [
                 'subject'          => 'Asunto',
                 'tax'              => 'Impuesto',
                 'title'            => 'Cotización',
+                'description'      => 'Descripción',
             ],
         ],
         'create' => [

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -423,6 +423,7 @@ return [
                 'subject'          => 'موضوع',
                 'tax'              => 'مالیات',
                 'title'            => 'نقل‌قول',
+                'description'      => 'توضیحات',
             ],
         ],
         'create' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -423,6 +423,7 @@ return [
                 'subject'          => 'Assunto',
                 'tax'              => 'Imposto',
                 'title'            => 'Cotação',
+                'description'      => 'Descrição',
             ],
         ],
         'create' => [

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -423,6 +423,7 @@ return [
                 'subject'          => 'Konu',
                 'tax'              => 'Vergi',
                 'title'            => 'Teklif',
+                'description'      => 'Açıklama',
             ],
         ],
         'create' => [

--- a/packages/Webkul/Admin/src/Resources/lang/vi/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi/app.php
@@ -423,6 +423,7 @@ return [
                 'subject'          => 'Chủ đề',
                 'tax'              => 'Thuế',
                 'title'            => 'Báo giá',
+                'description'      => 'Mô tả',
             ],
         ],
         'create' => [

--- a/packages/Webkul/Admin/src/Resources/views/quotes/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/quotes/pdf.blade.php
@@ -253,15 +253,14 @@
                     <table class="{{ app()->getLocale() }}">
                         <tbody>
                             <tr>
-                                <td style="padding: 6px 18px; border: none;">
+                                <td style="width: 15%; padding: 2px 18px; border: none; vertical-align: top;">
                                     <b>
                                         @lang('admin::app.quotes.index.pdf.description'):
                                     </b>
                                 </td>
                             </tr>
-
                             <tr>
-                                <td style="padding: 6px 18px;">
+                                <td style="width: 85%; padding: 2px 18px; border: none;">
                                     {!! $quote->description !!}
                                 </td>
                             </tr>

--- a/packages/Webkul/Admin/src/Resources/views/quotes/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/quotes/pdf.blade.php
@@ -100,7 +100,7 @@
                 border-collapse: separate;
                 margin-bottom: 16px;
             }
-            
+
             table thead th {
                 background-color: #E9EFFC;
                 color: #000DBB;
@@ -173,7 +173,7 @@
                         <tr>
                             <td style="width: 50%; padding: 2px 18px;border:none;">
                                 <b>
-                                    @lang('admin::app.quotes.index.pdf.quote-id'): 
+                                    @lang('admin::app.quotes.index.pdf.quote-id'):
                                 </b>
 
                                 <span>
@@ -195,7 +195,7 @@
                         <tr>
                             <td style="width: 50%; padding: 2px 18px;border:none;">
                                 <b>
-                                    @lang('admin::app.quotes.index.pdf.sales-person'): 
+                                    @lang('admin::app.quotes.index.pdf.sales-person'):
                                 </b>
 
                                 <span>
@@ -213,7 +213,7 @@
                                 </span>
                             </td>
                         </tr>
-                        
+
                         <tr>
                             <td style="width: 50%; padding: 2px 18px;border:none;">
                                 <b>
@@ -249,7 +249,25 @@
                         </tr>
                     </tbody>
                 </table>
+                @if ($quote->description)
+                    <table class="{{ app()->getLocale() }}">
+                        <tbody>
+                            <tr>
+                                <td style="padding: 6px 18px; border: none;">
+                                    <b>
+                                        @lang('admin::app.quotes.index.pdf.description'):
+                                    </b>
+                                </td>
+                            </tr>
 
+                            <tr>
+                                <td style="padding: 6px 18px;">
+                                    {!! $quote->description !!}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                @endif
                 <!-- Billing & Shipping Address -->
                 <table class="{{ $locale }}">
                     <thead>
@@ -285,7 +303,7 @@
                                     <div>{{ core()->country_name($quote->billing_address['country'] ?? '') }}</div>
                                 </td>
                             @endif
-                            
+
                             @if ($quote->shipping_address)
                                 <td style="width: 50%">
                                     <div>{{ $quote->shipping_address['address'] ?? ''}}</div>
@@ -358,7 +376,7 @@
                                     <td class="text-center">{!! core()->formatBasePrice($item->discount_amount, true) !!}</td>
 
                                     <td class="text-center">{!! core()->formatBasePrice($item->tax_amount, true) !!}</td>
-                                    
+
                                     <td class="text-center">{!! core()->formatBasePrice($item->total + $item->tax_amount - $item->discount_amount, true) !!}</td>
                                 </tr>
                             @endforeach
@@ -375,25 +393,25 @@
                                 <td>-</td>
                                 <td>{!! core()->formatBasePrice($quote->sub_total, true) !!}</td>
                             </tr>
-        
+
                             <tr>
                                 <td>@lang('admin::app.quotes.index.pdf.tax')</td>
                                 <td>-</td>
                                 <td>{!! core()->formatBasePrice($quote->tax_amount, true) !!}</td>
                             </tr>
-        
+
                             <tr>
                                 <td>@lang('admin::app.quotes.index.pdf.discount')</td>
                                 <td>-</td>
                                 <td>{!! core()->formatBasePrice($quote->discount_amount, true) !!}</td>
                             </tr>
-        
+
                             <tr>
                                 <td>@lang('admin::app.quotes.index.pdf.adjustment')</td>
                                 <td>-</td>
                                 <td>{!! core()->formatBasePrice($quote->adjustment_amount, true) !!}</td>
                             </tr>
-        
+
                             <tr>
                                 <td><strong>@lang('admin::app.quotes.index.pdf.grand-total')</strong></td>
                                 <td><strong>-</strong></td>


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
fix #2237 

## Description
<!--- Please describe your changes in detail. -->
This pull request resolves an issue where the quote description field was not rendered in the generated PDF.
Changes made:

- Added the description field rendering in pdf.blade.php.
- Added missing translation keys for the description label across supported languages.
Now, when a description is added to a quote, it is properly displayed in the generated PDF.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Go to Quotes section.
2. Create or edit an existing quote.
3. Add a description in the description field.
4. Save the quote.
5. Click on Print Quote to generate the PDF.
6. Verify that the description appears correctly in the PDF.

Also verify that:

- The description label is properly translated when switching application language.
- PDF layout remains intact.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
Not applicable. No Tailwind utility changes were made.