### PR TITLE
Fix: Add comma-separated formatting for Lead Value display

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/components/attributes/view/price.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/attributes/view/price.blade.php
@@ -1,9 +1,21 @@
+@php
+    $isLeadValue = $attribute->entity_type === 'leads'
+        && $attribute->code === 'lead_value';
+
+    $displayLabel = $value;
+
+    if ($isLeadValue && is_numeric($value)) {
+        $displayLabel = number_format((float) $value, 0);
+    }
+@endphp
+
 <x-admin::form.control-group.controls.inline.text
     type="inline"
     ::name="'{{ $attribute->code }}'"
-    ::value="'{{ $value }}'"
+    :value="$value ?? ''"
+    :value-label="$value == '' ? '--' : $displayLabel"
     position="left"
-    rules="required"
+    rules="required|{{ $attribute->validation }}"
     :label="$attribute->name"
     :placeholder="$attribute->name"
     ::errors="errors"


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix #2459 

## Description
<!--- Please describe your changes in detail. -->
This PR improves the readability of the Lead Value field on the Lead view page.
Previously, large numeric values were displayed without thousand separators and with trailing decimal zeros (e.g., 1000000.0000).

With this change:

- Lead Value is displayed in a comma-separated format (e.g., 1,000,000)
- Trailing unnecessary decimals are removed for better clarity
- Inline editing functionality remains unchanged
- Raw numeric value is preserved for saving and validation

The formatting is scoped specifically to the lead_value attribute under the leads entity and does not affect other price attributes or modules.
## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Navigate to Leads module.
2. Create a new lead.
3. Enter a large number in Lead Value (e.g., 1000000).
4. Save the lead.
5. Open the lead details page.
7. Click the inline edit icon for Lead Value.
8. Verify the input field shows the raw numeric value (e.g., 1000000).
9. Update the value (e.g., add one more 0) and save.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
- [ ] Tailwind classes reordered where applicable.