### PR TITLE
Fix: Pipeline should not be visible on public webform and must be admin-controlled.

### DIFF
--- a/database/migrations/2026_02_28_132314_add_lead_pipeline_id_to_web_forms_table.php
+++ b/database/migrations/2026_02_28_132314_add_lead_pipeline_id_to_web_forms_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::table('web_forms', function (Blueprint $table) {
             $table->unsignedInteger('lead_pipeline_id')
-              ->nullable()
-              ->after('create_lead');
+                ->nullable()
+                ->after('create_lead');
         });
     }
 

--- a/database/migrations/2026_02_28_132314_add_lead_pipeline_id_to_web_forms_table.php
+++ b/database/migrations/2026_02_28_132314_add_lead_pipeline_id_to_web_forms_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('web_forms', function (Blueprint $table) {
+            $table->unsignedInteger('lead_pipeline_id')
+              ->nullable()
+              ->after('create_lead');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('web_forms', function (Blueprint $table) {
+            $table->dropColumn('lead_pipeline_id');
+        });
+    }
+};

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/WebFormController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/WebFormController.php
@@ -100,12 +100,12 @@ class WebFormController extends Controller
     {
         $webForm = $this->webFormRepository->findOrFail($id);
 
-        $attributes = $this->attributeRepository->findWhere([
-            ['entity_type', 'IN', ['persons', 'leads']],
-            ['id', 'NOTIN', $webForm->attributes()->pluck('attribute_id')->toArray()],
-        ]);
+        $attributes = $this->attributeRepository->getWebformAttributes(
+            $webForm->attributes()->pluck('attribute_id')->toArray()
+        );
 
-        return view('admin::settings.web-forms.edit', compact('webForm', 'attributes'));
+        $pipelines = $this->pipelineRepository->all();
+        return view('admin::settings.web-forms.edit', compact('webForm', 'attributes', 'pipelines'));
     }
 
     /**

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/WebFormController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/WebFormController.php
@@ -50,8 +50,8 @@ class WebFormController extends Controller
      */
     public function create(): View
     {
-        $tempAttributes = $this->attributeRepository->findWhereIn('entity_type', ['persons', 'leads']);
-
+        $tempAttributes = $this->attributeRepository->getWebformAttributes([]);
+        $pipelines = $this->pipelineRepository->all();
         $attributes = [];
 
         foreach ($tempAttributes as $attribute) {
@@ -65,7 +65,7 @@ class WebFormController extends Controller
             }
         }
 
-        return view('admin::settings.web-forms.create', compact('attributes'));
+        return view('admin::settings.web-forms.create', compact('attributes', 'pipelines'));
     }
 
     /**

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/WebFormController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/WebFormController.php
@@ -105,6 +105,7 @@ class WebFormController extends Controller
         );
 
         $pipelines = $this->pipelineRepository->all();
+
         return view('admin::settings.web-forms.edit', compact('webForm', 'attributes', 'pipelines'));
     }
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/view/person.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/view/person.blade.php
@@ -16,20 +16,20 @@
                     @endif
                 </div>
             </x-slot>
-            
+
             <x-slot:content class="mt-4 !px-0 !pb-0">
                 <div class="flex gap-2">
                     {!! view_render_event('admin.leads.view.person.avatar.before', ['lead' => $lead]) !!}
-        
+
                     <!-- Person Initials -->
                     <x-admin::avatar :name="$lead->person->name" />
-        
+
                     {!! view_render_event('admin.leads.view.person.avatar.after', ['lead' => $lead]) !!}
-        
+
                     <!-- Person Details -->
                     <div class="flex flex-col gap-1">
                         {!! view_render_event('admin.leads.view.person.name.before', ['lead' => $lead]) !!}
-        
+
                         <a
                             href="{{ route('admin.contacts.persons.view', $lead->person->id) }}"
                             class="font-semibold text-brandColor"
@@ -37,11 +37,11 @@
                         >
                             {{ $lead->person->name }}
                         </a>
-        
+
                         {!! view_render_event('admin.leads.view.person.name.after', ['lead' => $lead]) !!}
-        
+
                         {!! view_render_event('admin.leads.view.person.job_title.before', ['lead' => $lead]) !!}
-        
+
                         @if ($lead->person->job_title)
                             <span class="dark:text-white">
                                 @if ($lead->person->organization)
@@ -54,45 +54,45 @@
                                 @endif
                             </span>
                         @endif
-        
+
                         {!! view_render_event('admin.leads.view.person.job_title.after', ['lead' => $lead]) !!}
-                    
+
                         {!! view_render_event('admin.leads.view.person.email.before', ['lead' => $lead]) !!}
-        
+
                         @foreach ($lead->person->emails as $email)
                             <div class="flex gap-1">
-                                <a 
+                                <a
                                     class="text-brandColor"
                                     href="mailto:{{ $email['value'] }}"
                                 >
                                     {{ $email['value'] }}
                                 </a>
-        
+
                                 <span class="text-gray-500 dark:text-gray-300">
                                     ({{ $email['label'] }})
                                 </span>
                             </div>
                         @endforeach
-        
+
                         {!! view_render_event('admin.leads.view.person.email.after', ['lead' => $lead]) !!}
-        
+
                         {!! view_render_event('admin.leads.view.person.contact_numbers.before', ['lead' => $lead]) !!}
-                    
-                        @foreach ($lead->person->contact_numbers as $contactNumber)
+
+                        @foreach ($lead->person->contact_numbers ?? [] as $contactNumber)
                             <div class="flex gap-1">
-                                <a  
+                                <a
                                     class="text-brandColor"
                                     href="callto:{{ $contactNumber['value'] }}"
                                 >
                                     {{ $contactNumber['value'] }}
                                 </a>
-        
+
                                 <span class="text-gray-500 dark:text-gray-300">
                                     ({{ $contactNumber['label'] }})
                                 </span>
                             </div>
                         @endforeach
-        
+
                         {!! view_render_event('admin.leads.view.person.contact_numbers.after', ['lead' => $lead]) !!}
                     </div>
                 </div>

--- a/packages/Webkul/Admin/src/Resources/views/settings/web-forms/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/web-forms/create.blade.php
@@ -121,7 +121,7 @@
                                 name="create_lead"
                                 value="1"
                                 :label="trans('admin::app.settings.webforms.create.create-lead')"
-                                :checked="false"
+                                v-model="createLead"
                             />
 
                         </x-admin::form.control-group>
@@ -497,6 +497,27 @@
                                 />
 
                                 <x-admin::form.control-group.error control-name="submit_button_label" />
+                            </x-admin::form.control-group>
+                            <x-admin::form.control-group class="mt-4">
+                                <x-admin::form.control-group.label>
+                                    Pipeline
+                                </x-admin::form.control-group.label>
+
+                                <x-admin::form.control-group.control
+                                    type="select"
+                                    name="lead_pipeline_id"
+                                >
+                                    <option value="">Use Default Pipeline</option>
+
+                                    @foreach($pipelines as $pipeline)
+                                        <option value="{{ $pipeline->id }}"
+                                            {{ old('lead_pipeline_id') == $pipeline->id ? 'selected' : '' }}>
+                                            {{ $pipeline->name }}
+                                        </option>
+                                    @endforeach
+                                </x-admin::form.control-group.control>
+
+                                <x-admin::form.control-group.error control-name="lead_pipeline_id" />
                             </x-admin::form.control-group>
                         </x-slot>
                     </x-admin::accordion>

--- a/packages/Webkul/Admin/src/Resources/views/settings/web-forms/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/web-forms/edit.blade.php
@@ -527,6 +527,27 @@
 
                                 <x-admin::form.control-group.error control-name="submit_button_label" />
                             </x-admin::form.control-group>
+                            <x-admin::form.control-group class="mt-4">
+                                <x-admin::form.control-group.label>
+                                    Pipeline
+                                </x-admin::form.control-group.label>
+
+                                <x-admin::form.control-group.control
+                                    type="select"
+                                    name="lead_pipeline_id"
+                                    :value="old('lead_pipeline_id') ?? $webForm->lead_pipeline_id"
+                                >
+                                    <option value="">Use Default Pipeline</option>
+
+                                    @foreach($pipelines as $pipeline)
+                                        <option value="{{ $pipeline->id }}">
+                                            {{ $pipeline->name }}
+                                        </option>
+                                    @endforeach
+                                </x-admin::form.control-group.control>
+
+                                <x-admin::form.control-group.error control-name="lead_pipeline_id" />
+                            </x-admin::form.control-group>
                         </x-slot>
                     </x-admin::accordion>
                 </div>

--- a/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
@@ -176,6 +176,7 @@ class AttributeRepository extends Repository
             return app($lookup['repository'])->find($entityId, $columns);
         }
     }
+
     public function getWebformAttributes(array $excludedAttributeIds = [])
     {
         return $this->model

--- a/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
+++ b/packages/Webkul/Attribute/src/Repositories/AttributeRepository.php
@@ -176,4 +176,15 @@ class AttributeRepository extends Repository
             return app($lookup['repository'])->find($entityId, $columns);
         }
     }
+    public function getWebformAttributes(array $excludedAttributeIds = [])
+    {
+        return $this->model
+            ->whereIn('entity_type', ['persons', 'leads'])
+            ->whereNotIn('id', $excludedAttributeIds)
+            ->whereNotIn('code', [
+                'lead_pipeline_id',
+                'lead_pipeline_stage_id',
+            ])
+            ->get();
+    }
 }

--- a/packages/Webkul/WebForm/src/Http/Controllers/WebFormController.php
+++ b/packages/Webkul/WebForm/src/Http/Controllers/WebFormController.php
@@ -70,12 +70,31 @@ class WebFormController extends Controller
 
             $data['entity_type'] = 'leads';
 
-            $data['person'] = request('persons');
+            $personData = request('persons');
+            if (! isset($personData['contact_numbers']) || ! is_array($personData['contact_numbers'])) {
+                $personData['contact_numbers'] = [];
+            }
+
+            if ($person) {
+                $personModel = $person;
+            } else {
+                request()->request->add(['entity_type' => 'persons']);
+                $personData['entity_type'] = 'persons';
+
+                $personModel = $this->personRepository->create($personData);
+            }
+
+            $data['person'] = $personModel->toArray();
 
             $data['status'] = 1;
 
-            $pipeline = $this->pipelineRepository->getDefaultPipeline();
+            $pipeline = $webForm->lead_pipeline_id
+                    ? $this->pipelineRepository->find($webForm->lead_pipeline_id)
+                    : null;
 
+            if (! $pipeline) {
+                $pipeline = $this->pipelineRepository->getDefaultPipeline();
+            }
             $stage = $pipeline->stages()->first();
 
             $data['lead_pipeline_id'] = $pipeline->id;

--- a/packages/Webkul/WebForm/src/Models/WebForm.php
+++ b/packages/Webkul/WebForm/src/Models/WebForm.php
@@ -15,6 +15,7 @@ class WebForm extends Model implements WebFormContract
         'submit_success_action',
         'submit_success_content',
         'create_lead',
+        'lead_pipeline_id',
         'background_color',
         'form_background_color',
         'form_title_color',


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix #2232 

## Description
<!--- Please describe your changes in detail. -->
This PR improves the Webform lead creation flow by removing pipeline selection from the public form and allowing administrators to configure the pipeline internally while creating or editing a webform.

Key Changes::

- Added `lead_pipeline_id` to `web_forms` table.
- Added pipeline selection in Webform Create and Edit (admin only).
- Updated lead creation logic to assign leads to the selected pipeline.
- Added fallback to default pipeline if none is selected.
- Ensured pipeline is not exposed in public webform.
- Added null-safe handling for `contact_numbers` to prevent lead view crash.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Create two pipelines.
2. Create a webform and enable "Create Lead".
3. Select Pipeline A and save.
4. Submit the public form → lead should go to Pipeline A.
5. Edit the webform and change to Pipeline B.
6. Submit again → new lead should go to Pipeline B.
7. Leave pipeline empty → lead should use default pipeline.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
- [x] Tailwind classes reordered where applicable.