### PR TITLE
Fix: Enable search in Imports datagrid by configuring searchable columns

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ImportDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Settings/DataTransfer/ImportDataGrid.php
@@ -35,6 +35,7 @@ class ImportDataGrid extends DataGrid
             'index'      => 'id',
             'label'      => trans('admin::app.settings.data-transfer.imports.index.datagrid.id'),
             'type'       => 'integer',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);
@@ -43,6 +44,7 @@ class ImportDataGrid extends DataGrid
             'index'      => 'type',
             'label'      => trans('admin::app.settings.data-transfer.imports.index.datagrid.type'),
             'type'       => 'string',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);
@@ -51,6 +53,7 @@ class ImportDataGrid extends DataGrid
             'index'      => 'state',
             'label'      => trans('admin::app.settings.data-transfer.imports.index.datagrid.state'),
             'type'       => 'string',
+            'searchable' => true,
             'filterable' => true,
             'sortable'   => true,
         ]);
@@ -59,6 +62,7 @@ class ImportDataGrid extends DataGrid
             'index'      => 'file_path',
             'label'      => trans('admin::app.settings.data-transfer.imports.index.datagrid.uploaded-file'),
             'type'       => 'string',
+            'searchable' => true,
             'closure'    => function ($row) {
                 return '<a href="'.route('admin.settings.data_transfer.imports.download', $row->id).'" class="cursor-pointer text-blue-600 hover:underline">'.$row->file_path.'<a>';
             },
@@ -68,6 +72,7 @@ class ImportDataGrid extends DataGrid
             'index'      => 'error_file_path',
             'label'      => trans('admin::app.settings.data-transfer.imports.index.datagrid.error-file'),
             'type'       => 'string',
+            'searchable' => true,
             'closure'    => function ($row) {
                 if (empty($row->error_file_path)) {
                     return '';

--- a/tests/Feature/ImportSearchTest.php
+++ b/tests/Feature/ImportSearchTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+
+it('filters the datagrid by search term', function () {
+    $admin = getDefaultAdmin();
+
+    // Clean up before test
+    DB::table('imports')->delete();
+
+    // Create a matching import
+    DB::table('imports')->insert([
+        'state' => 'completed',
+        'type' => 'contacts',
+        'action' => 'append',
+        'validation_strategy' => 'stop-on-errors',
+        'allowed_errors' => 10,
+        'processed_rows_count' => 5,
+        'invalid_rows_count' => 0,
+        'errors_count' => 0,
+        'field_separator' => ',',
+        'file_path' => 'import/target-file-xyx1.csv',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Create a non-matching import
+    DB::table('imports')->insert([
+        'state' => 'pending',
+        'type' => 'products',
+        'action' => 'append',
+        'validation_strategy' => 'stop-on-errors',
+        'allowed_errors' => 10,
+        'processed_rows_count' => 5,
+        'invalid_rows_count' => 0,
+        'errors_count' => 0,
+        'field_separator' => ',',
+        'file_path' => 'import/other-file-zzz.csv',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    test()->actingAs($admin)
+        ->getJson(route('admin.settings.data_transfer.imports.index', [
+            'filters' => [
+                'all' => ['target-file'],
+            ]
+        ]))
+        ->assertJsonFragment([
+            'file_path' => 'import/target-file-xyx1.csv'
+        ])
+        ->assertJsonMissing([
+            'file_path' => 'import/other-file-zzz.csv'
+        ]);
+});


### PR DESCRIPTION
## Issue Reference
Fixes #2464

## Description
The Imports listing page search input was not filtering results.

Root cause:
The Imports datagrid did not define any columns as `searchable => true`.  
Krayin’s datagrid global search only applies filtering to columns explicitly marked as searchable.  
As a result, the filter builder generated no restrictive conditions and returned the full dataset.

## Fix
Added `searchable => true` to the following columns in `ImportDataGrid.php`:

- id
- type
- state
- file_path
- error_file_path

This enables proper SQL `LIKE` filtering for the global search scope.

## Tests
Added a feature test (`ImportSearchTest.php`) that:

- Seeds two imports with different attributes
- Sends a global search request
- Asserts only the matching record is returned
- Ensures non-matching records are excluded

## How To Test Manually
1. Navigate to Dashboard → Settings → Imports
2. Enter a search term that matches one record
3. Confirm only matching results are displayed
4. Enter a random string → confirm empty result
5. Clear search → confirm full list restored

## Scope
This PR strictly fixes the Imports datagrid search behavior and adds regression coverage.
No unrelated files were modified.