### PR TITLE
Fix webform attribute button label across translations

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -914,7 +914,7 @@ return [
             ],
             'create' => [
                 'title'                    => 'إنشاء استمارة ويب',
-                'add-attribute-btn'        => 'زر إضافة سمة',
+                'add-attribute-btn'        => 'إضافة سمة',
                 'attribute-label-color'    => 'لون تسمية السمة',
                 'attributes'               => 'السمات',
                 'attributes-info'          => 'أضف سمات مخصصة إلى النموذج.',
@@ -941,7 +941,7 @@ return [
                 'enter-value'              => 'أدخل القيمة',
             ],
             'edit' => [
-                'add-attribute-btn'        => 'زر إضافة سمة',
+                'add-attribute-btn'        => 'إضافة سمة',
                 'attribute-label-color'    => 'لون تسمية السمة',
                 'attributes'               => 'السمات',
                 'attributes-info'          => 'أضف سمات مخصصة إلى النموذج.',

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -1011,7 +1011,7 @@ return [
 
             'create' => [
                 'title'                    => 'Create Webform',
-                'add-attribute-btn'        => 'Add Attribute Button',
+                'add-attribute-btn'        => 'Add Attribute',
                 'attribute-label-color'    => 'Attribute Label Color',
                 'attributes'               => 'Attributes',
                 'attributes-info'          => 'Add custom attributes to the form.',
@@ -1039,7 +1039,7 @@ return [
             ],
 
             'edit' => [
-                'add-attribute-btn'         => 'Add Attribute Button',
+                'add-attribute-btn'         => 'Add Attribute',
                 'attribute-label-color'     => 'Attribute Label Color',
                 'attributes'                => 'Attributes',
                 'attributes-info'           => 'Add custom attributes to the form.',

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -914,7 +914,7 @@ return [
             ],
             'create' => [
                 'title'                    => 'Crear formulario web',
-                'add-attribute-btn'        => 'Agregar Botón de Atributo',
+                'add-attribute-btn'        => 'Agregar Atributo',
                 'attribute-label-color'    => 'Color de Etiqueta del Atributo',
                 'attributes'               => 'Atributos',
                 'attributes-info'          => 'Agregue atributos personalizados al formulario.',
@@ -941,7 +941,7 @@ return [
                 'enter-value'              => 'Introducir valor',
             ],
             'edit' => [
-                'add-attribute-btn'        => 'Agregar Botón de Atributo',
+                'add-attribute-btn'        => 'Agregar Atributo',
                 'attribute-label-color'    => 'Color de Etiqueta del Atributo',
                 'attributes'               => 'Atributos',
                 'attributes-info'          => 'Agregue atributos personalizados al formulario.',

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -914,7 +914,7 @@ return [
             ],
             'create' => [
                 'title'                    => 'ایجاد فرم وب',
-                'add-attribute-btn'        => 'افزودن دکمه ویژگی',
+                'add-attribute-btn'        => 'افزودن ویژگی',
                 'attribute-label-color'    => 'رنگ برچسب ویژگی',
                 'attributes'               => 'ویژگی‌ها',
                 'attributes-info'          => 'ویژگی‌های سفارشی را به فرم اضافه کنید.',
@@ -941,7 +941,7 @@ return [
                 'enter-value'              => 'مقدار را وارد کنید',
             ],
             'edit' => [
-                'add-attribute-btn'        => 'افزودن دکمه ویژگی',
+                'add-attribute-btn'        => 'افزودن ویژگی',
                 'attribute-label-color'    => 'رنگ برچسب ویژگی',
                 'attributes'               => 'ویژگی‌ها',
                 'attributes-info'          => 'ویژگی‌های سفارشی را به فرم اضافه کنید.',

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -914,7 +914,7 @@ return [
             ],
             'create' => [
                 'title'                    => 'Adicionar Webform',
-                'add-attribute-btn'        => 'Adicionar Botão de Atributo',
+                'add-attribute-btn'        => 'Adicionar Atributo',
                 'attribute-label-color'    => 'Cor do Rótulo do Atributo',
                 'attributes'               => 'Atributos',
                 'attributes-info'          => 'Adicione atributos personalizados ao formulário.',
@@ -941,7 +941,7 @@ return [
                 'enter-value'              => 'Inserir Valor',
             ],
             'edit' => [
-                'add-attribute-btn'        => 'Adicionar Botão de Atributo',
+                'add-attribute-btn'        => 'Adicionar Atributo',
                 'attribute-label-color'    => 'Cor do Rótulo do Atributo',
                 'attributes'               => 'Atributos',
                 'attributes-info'          => 'Adicione atributos personalizados ao formulário.',

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -914,7 +914,7 @@ return [
             ],
             'create' => [
                 'title'                    => 'Web Formu Oluştur',
-                'add-attribute-btn'        => 'Öznitelik Düğmesi Ekle',
+                'add-attribute-btn'        => 'Öznitelik Ekle',
                 'attribute-label-color'    => 'Öznitelik Etiketi Rengi',
                 'attributes'               => 'Öznitelikler',
                 'attributes-info'          => 'Forma özel öznitelikler ekleyin.',
@@ -941,7 +941,7 @@ return [
                 'enter-value'              => 'Değer Gir',
             ],
             'edit' => [
-                'add-attribute-btn'        => 'Öznitelik Düğmesi Ekle',
+                'add-attribute-btn'        => 'Öznitelik Ekle',
                 'attribute-label-color'    => 'Öznitelik Etiketi Rengi',
                 'attributes'               => 'Öznitelikler',
                 'attributes-info'          => 'Forma özel öznitelikler ekleyin.',

--- a/packages/Webkul/Admin/src/Resources/lang/vi/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi/app.php
@@ -914,7 +914,7 @@ return [
             ],
             'create' => [
                 'title'                    => 'Tạo Biểu mẫu Web',
-                'add-attribute-btn'        => 'Thêm Nút Thuộc Tính',
+                'add-attribute-btn'        => 'Thêm Thuộc Tính',
                 'attribute-label-color'    => 'Màu Nhãn Thuộc Tính',
                 'attributes'               => 'Thuộc Tính',
                 'attributes-info'          => 'Thêm các thuộc tính tùy chỉnh vào biểu mẫu.',
@@ -941,7 +941,7 @@ return [
                 'enter-value'              => 'Nhập Giá Trị',
             ],
             'edit' => [
-                'add-attribute-btn'        => 'Thêm Nút Thuộc Tính',
+                'add-attribute-btn'        => 'Thêm Thuộc Tính',
                 'attribute-label-color'    => 'Màu Nhãn Thuộc Tính',
                 'attributes'               => 'Thuộc Tính',
                 'attributes-info'          => 'Thêm các thuộc tính tùy chỉnh vào biểu mẫu.',


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix  #2476 

## Description
<!--- Please describe your changes in detail. -->
This PR updates the incorrect label "Add Attribute Button" to "Add Attribute" in Webform pages.

The previous translation included the word "button", which is unnecessary and inconsistent with common UI conventions. This change updates the translation across all affected language files (7 languages) so the button correctly reflects the action.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Login to the Admin Panel
2. Navigate to Settings → Web Forms
3. Click Create Webform
4. Scroll to the Attributes section
5. Verify the button label shows "Add Attribute"
Repeat the same test on:
6. Open an existing webform using Edit
7. Check the Attributes section


## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
No Tailwind changes were made in this PR.