### PR TITLE
Fix: Textarea field not rendered in WebForm

### DIFF
--- a/packages/Webkul/WebForm/src/Resources/views/settings/web-forms/controls.blade.php
+++ b/packages/Webkul/WebForm/src/Resources/views/settings/web-forms/controls.blade.php
@@ -31,6 +31,20 @@
 
                 @break
 
+            @case('textarea')
+                <x-web_form::form.control-group.control
+                    type="textarea"
+                    :name="$fieldName"
+                    :id="$fieldName"
+                    :rules="$validations"
+                    :label="$attribute->name ?? $parentAttribute->name"
+                    :placeholder="$attribute->placeholder"
+                />
+
+                <x-web_form::form.control-group.error :control-name="$fieldName" />
+
+                @break
+
             @case('price')
                 <x-web_form::form.control-group.control
                     type="text"

--- a/packages/Webkul/WebForm/src/Resources/views/settings/web-forms/controls.blade.php
+++ b/packages/Webkul/WebForm/src/Resources/views/settings/web-forms/controls.blade.php
@@ -40,7 +40,6 @@
                     :label="$attribute->name ?? $parentAttribute->name"
                     :placeholder="$attribute->placeholder"
                 />
-
                 <x-web_form::form.control-group.error :control-name="$fieldName" />
 
                 @break


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
Fix #2475 

## Description
<!--- Please describe your changes in detail. -->
Added support for textarea attribute type in WebForm. Previously, textarea fields were not rendered, showing only the label.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Create a WebForm with a textarea attribute.
2. View the WebForm.
3. Verify the textarea field is visible and working.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
No Tailwind changes were made in this PR.