### PR TITLE
Fix Won/Lost modal failure and broken dashboard chart

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/settings/pipelines/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/pipelines/create.blade.php
@@ -157,23 +157,24 @@
                                     <!-- Stage Title and Action -->
                                     <div class="flex items-center justify-between">
                                         <span class="py-1 font-medium dark:text-gray-300">
-                                            @{{ element.name ? element.name : '@lang('admin::app.settings.pipelines.create.newly-added')'}} 
+                                            @{{ element.name ? element.name : '@lang('admin::app.settings.pipelines.create.newly-added')'}}
                                         </span>
 
                                         <!-- Drag Icon -->
                                         <i
-                                            v-if="isDragable(element)" 
+                                            v-if="isDragable(element)"
                                             class="icon-move cursor-grab rounded-md p-1 text-2xl transition-all hover:bg-gray-100 dark:hover:bg-gray-950"
                                         >
                                         </i>
                                     </div>
-                                    
+
                                     <!-- Card Body -->
                                     <div>
                                         <input
                                             type="hidden"
                                             id="slug"
-                                            :value="slugify(element.name)"
+                                            :value="slugify(element.code ? element.code : element.name)"
+
                                             :name="'stages[' + element.id + '][code]'"
                                         />
 
@@ -184,7 +185,7 @@
                                             <x-admin::form.control-group.label class="required">
                                                 @lang('admin::app.settings.pipelines.create.name')
                                             </x-admin::form.control-group.label>
-                                            
+
                                             <x-admin::form.control-group.control
                                                 type="text"
                                                 ::name="'stages[' + element.id + '][name]'"
@@ -227,16 +228,16 @@
                                         {!! view_render_event('admin.settings.pipelines.create.form.stages.probability.after') !!}
                                     </div>
                                 </div>
-                                
+
                                 {!! view_render_event('admin.settings.pipelines.create.form.stages.delete_button.before') !!}
 
                                 <div
-                                    class="flex cursor-pointer items-center gap-2 border-t border-gray-200 p-2 text-red-600 dark:border-gray-800" 
-                                    @click="removeStage(element)" 
+                                    class="flex cursor-pointer items-center gap-2 border-t border-gray-200 p-2 text-red-600 dark:border-gray-800"
+                                    @click="removeStage(element)"
                                     v-if="isDragable(element)"
                                 >
                                     <i class="icon-delete text-2xl"></i>
-                                    
+
                                     @lang('admin::app.settings.pipelines.create.delete-stage')
                                 </div>
 
@@ -287,7 +288,7 @@
                     return {
                         stages: [{
                             'id': 'stage_1',
-                            'code': 'new', 
+                            'code': 'new',
                             'name': "@lang('admin::app.settings.pipelines.create.new-stage')",
                             'probability': 100
                         }, {
@@ -346,7 +347,7 @@
                                 }
 
                                 this.removeUniqueNameErrors();
-                                
+
                                 this.$emitter.emit('add-flash', { type: 'success', message: "@lang('admin::app.settings.pipelines.create.stage-delete-success')" });
                             }
                         });
@@ -388,7 +389,7 @@
                             });
 
                             if (filteredStages.length > 1) {
-                                return "{!! trans('admin::app.settings.pipelines.create.duplicate-name') !!}";
+                                return @json(trans('admin::app.settings.pipelines.create.duplicate-name'));
                             }
 
                             this.removeUniqueNameErrors();
@@ -415,7 +416,7 @@
 
                     handleDragging(event) {
                         const draggedElement = event.draggedContext.element;
-                        
+
                         const relatedElement = event.relatedContext.element;
 
                         return this.isDragable(draggedElement) && this.isDragable(relatedElement);

--- a/packages/Webkul/Admin/src/Resources/views/settings/pipelines/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/pipelines/edit.blade.php
@@ -338,7 +338,7 @@
                             });
 
                             if (filteredStages.length > 1) {
-                                return "{!! trans('admin::app.settings.pipelines.create.duplicate-name') !!}";
+                                return @json(trans('admin::app.settings.pipelines.create.duplicate-name'));
                             }
 
                             this.removeUniqueNameErrors();


### PR DESCRIPTION
## Problem
When a new pipeline is created, the code column in the lead_pipeline_stages table is populated with a slug of the stage name. This causes the "Won/Lost" modal to fail when a lead is completed and breaks the "Won/Lost" chart on the dashboard.

<img width="622" height="145" alt="image" src="https://github.com/user-attachments/assets/e14c3607-6ab3-49a2-b64f-a965d264ba87" />

## Solution
Preserve English stage codes when locale is non-English. Use slugify(element.code ? element.code : element.name) to mirror edit.blade.php behaviour. Prevents "new"/"won"/"lost" being saved as translated slugs on pipeline creation

<img width="620" height="146" alt="image" src="https://github.com/user-attachments/assets/b4abd41f-3a1c-4c17-89af-de65cc7adad8" />

## Affected files
- `packages/Webkul/Admin/src/Resources/views/settings/pipelines/create.blade.php`
- `packages/Webkul/Admin/src/Resources/views/settings/pipelines/edit.blade.php`
