### PR TITLE
Fix undefined index when contact_numbers is empty after filtering

### DIFF
--- a/packages/Webkul/Admin/src/Resources/views/settings/pipelines/create.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/pipelines/create.blade.php
@@ -157,23 +157,24 @@
                                     <!-- Stage Title and Action -->
                                     <div class="flex items-center justify-between">
                                         <span class="py-1 font-medium dark:text-gray-300">
-                                            @{{ element.name ? element.name : '@lang('admin::app.settings.pipelines.create.newly-added')'}} 
+                                            @{{ element.name ? element.name : '@lang('admin::app.settings.pipelines.create.newly-added')'}}
                                         </span>
 
                                         <!-- Drag Icon -->
                                         <i
-                                            v-if="isDragable(element)" 
+                                            v-if="isDragable(element)"
                                             class="icon-move cursor-grab rounded-md p-1 text-2xl transition-all hover:bg-gray-100 dark:hover:bg-gray-950"
                                         >
                                         </i>
                                     </div>
-                                    
+
                                     <!-- Card Body -->
                                     <div>
                                         <input
                                             type="hidden"
                                             id="slug"
-                                            :value="slugify(element.name)"
+                                            :value="slugify(element.code ? element.code : element.name)"
+
                                             :name="'stages[' + element.id + '][code]'"
                                         />
 
@@ -184,7 +185,7 @@
                                             <x-admin::form.control-group.label class="required">
                                                 @lang('admin::app.settings.pipelines.create.name')
                                             </x-admin::form.control-group.label>
-                                            
+
                                             <x-admin::form.control-group.control
                                                 type="text"
                                                 ::name="'stages[' + element.id + '][name]'"
@@ -227,16 +228,16 @@
                                         {!! view_render_event('admin.settings.pipelines.create.form.stages.probability.after') !!}
                                     </div>
                                 </div>
-                                
+
                                 {!! view_render_event('admin.settings.pipelines.create.form.stages.delete_button.before') !!}
 
                                 <div
-                                    class="flex cursor-pointer items-center gap-2 border-t border-gray-200 p-2 text-red-600 dark:border-gray-800" 
-                                    @click="removeStage(element)" 
+                                    class="flex cursor-pointer items-center gap-2 border-t border-gray-200 p-2 text-red-600 dark:border-gray-800"
+                                    @click="removeStage(element)"
                                     v-if="isDragable(element)"
                                 >
                                     <i class="icon-delete text-2xl"></i>
-                                    
+
                                     @lang('admin::app.settings.pipelines.create.delete-stage')
                                 </div>
 
@@ -287,7 +288,7 @@
                     return {
                         stages: [{
                             'id': 'stage_1',
-                            'code': 'new', 
+                            'code': 'new',
                             'name': "@lang('admin::app.settings.pipelines.create.new-stage')",
                             'probability': 100
                         }, {
@@ -346,7 +347,7 @@
                                 }
 
                                 this.removeUniqueNameErrors();
-                                
+
                                 this.$emitter.emit('add-flash', { type: 'success', message: "@lang('admin::app.settings.pipelines.create.stage-delete-success')" });
                             }
                         });
@@ -388,7 +389,7 @@
                             });
 
                             if (filteredStages.length > 1) {
-                                return "{!! trans('admin::app.settings.pipelines.create.duplicate-name') !!}";
+                                return @json(trans('admin::app.settings.pipelines.create.duplicate-name'));
                             }
 
                             this.removeUniqueNameErrors();
@@ -415,7 +416,7 @@
 
                     handleDragging(event) {
                         const draggedElement = event.draggedContext.element;
-                        
+
                         const relatedElement = event.relatedContext.element;
 
                         return this.isDragable(draggedElement) && this.isDragable(relatedElement);

--- a/packages/Webkul/Admin/src/Resources/views/settings/pipelines/edit.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/settings/pipelines/edit.blade.php
@@ -338,7 +338,7 @@
                             });
 
                             if (filteredStages.length > 1) {
-                                return "{!! trans('admin::app.settings.pipelines.create.duplicate-name') !!}";
+                                return @json(trans('admin::app.settings.pipelines.create.duplicate-name'));
                             }
 
                             this.removeUniqueNameErrors();

--- a/packages/Webkul/Contact/src/Repositories/PersonRepository.php
+++ b/packages/Webkul/Contact/src/Repositories/PersonRepository.php
@@ -176,7 +176,9 @@ class PersonRepository extends Repository
         if (isset($data['contact_numbers'])) {
             $data['contact_numbers'] = collect($data['contact_numbers'])->filter(fn ($number) => ! is_null($number['value']))->toArray();
 
-            $data['unique_id'] .= '|'.$data['contact_numbers'][0]['value'];
+            if (! empty($data['contact_numbers'])) {
+                $data['unique_id'] .= '|'.$data['contact_numbers'][0]['value'];
+            }
         }
 
         return $data;


### PR DESCRIPTION
## Issue Reference
N/A

## Description
When saving a person with contact numbers, the code filters out entries where `value` is `null`:

```php
$data['contact_numbers'] = collect($data['contact_numbers'])
    ->filter(fn ($number) => ! is_null($number['value']))
    ->toArray();

## How To Test This?

1. Go to Contacts → Persons → Create (or Leads → Create)
2. Leave the phone field blank
3. Fill in the other required fields and save
4. Without the fix: triggers Undefined array key 0 in PersonRepository::sanitizeRequestedPersonData (error 500)
5. With the fix: person is saved successfully