### PR TITLE
fix(pt_BR): correct date-to label in leads datagrid (closes #2520)

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -1778,7 +1778,7 @@ return [
                 'contact-person' => 'Pessoa de Contato',
                 'stage' => 'Etapa',
                 'rotten-lead' => 'Negócio estagnado',
-                'date-to' => 'Data fechamento',
+                'date-to' => 'Data esperada de fechamento',
                 'created-at' => 'Criado em',
                 'no' => 'Não',
                 'yes' => 'Sim',
@@ -1800,7 +1800,7 @@ return [
                     'source' => 'Origem',
                     'title' => 'Título',
                     'tags' => 'Tags',
-                    'expected-close-date' => 'Data Esperada de Fechamento',
+                    'expected-close-date' => 'Data esperada de fechamento',
                     'created-at' => 'Criado em',
                 ],
                 'toolbar' => [


### PR DESCRIPTION
## Summary
- Fixes incorrect pt_BR translation for `date-to` key in leads datagrid (`leads.index.datagrid`)
- Was: `"Data fechamento"` (ambiguous — same meaning as `closed_at`)
- Now: `"Data esperada de fechamento"` (consistent with `expected-close-date`)
- Also normalizes capitalization of `expected-close-date` in the kanban section

## Related issue
Closes #2520