### PR TITLE
Add Portuguese translations for stages in app.php

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -1811,6 +1811,13 @@ return [
                     'expected-close-date' => 'Data esperada de fechamento',
                     'created-at' => 'Criado em',
                 ],
+                'stages' =>[
+                    'won-value' => 'Valor Ganho',
+                    'need-more-info' => 'Detalhamento',
+                    'closed-at' => 'Encerrado em:',
+                    'save-btn' => 'Salvar',
+                    'lost-reason' => 'Motivo da Perda', 
+                    ],
                 'toolbar' => [
                     'search' => [
                         'title' => 'Buscar por título',


### PR DESCRIPTION
The following lines were not being translated into Brazilian Portuguese when the deal status was changed to Won or Lost:

admin::app.leads.index.kanban.stages.need-more-info admin::app.leads.index.kanban.stages.won-value
admin::app.leads.index.kanban.stages.lost-reason
admin::app.leads.index.kanban.stages.closed-at
admin::app.leads.index.kanban.stages.save-btn

./packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php L: 248
L: 264
L: 279
L: 292
L: 298
L: 309

## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
<!--- Please describe your changes in detail. -->

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->