### PR TITLE
Fix/CVE-2026-38526 unrestricted file upload

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/TinyMCEController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/TinyMCEController.php
@@ -17,10 +17,19 @@ class TinyMCEController extends Controller
     private string $storagePath = 'tinymce';
 
     /**
+     * The image extensions allowed to be uploaded through the editor.
+     */
+    private string $allowedExtensions = 'bmp,gif,jpeg,jpg,png,svg,webp';
+
+    /**
      * Upload file from tinymce.
      */
     public function upload(): JsonResponse
     {
+        $this->validate(request(), [
+            'file' => 'required|file|mimes:'.$this->allowedExtensions.'|max:2048',
+        ]);
+
         $media = $this->storeMedia();
 
         if (! empty($media)) {
@@ -47,7 +56,13 @@ class TinyMCEController extends Controller
             return [];
         }
 
-        $filename = md5($file->getClientOriginalName().time()).'.'.$file->getClientOriginalExtension();
+        $extension = $file->extension();
+
+        if (! in_array($extension, explode(',', $this->allowedExtensions), true)) {
+            return [];
+        }
+
+        $filename = md5($file->getClientOriginalName().time()).'.'.$extension;
 
         $path = $file->storeAs($this->storagePath, $filename);
 

--- a/packages/Webkul/Admin/src/Http/Controllers/TinyMCEController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/TinyMCEController.php
@@ -27,7 +27,7 @@ class TinyMCEController extends Controller
     public function upload(): JsonResponse
     {
         $this->validate(request(), [
-            'file' => 'required|file|mimes:'.$this->allowedExtensions.'|max:2048',
+            'file' => 'required|file|mimes:'.$this->allowedExtensions.'|max:8192',
         ]);
 
         $media = $this->storeMedia();


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

- CVE-2026-38526 Security Advisory
- https://github.com/TREXNEGRO/Security-Advisories/tree/main/CVE-2026-38526
- https://socradar.io/blog/cve-2026-38526-krayin-crm-rce/
- https://nvd.nist.gov/vuln/detail/CVE-2026-38526

---

## Description

This pull request addresses **CVE-2026-38526**, a critical authenticated Remote Code Execution (RCE) vulnerability affecting **Krayin CRM v2.2.x** caused by unrestricted PHP file uploads through the TinyMCE media upload endpoint.

### Security Advisory

- **CVE:** CVE-2026-38526
- **CVSS Score:** 9.9 (Critical)
- **CWE:** CWE-434 - Unrestricted Upload of File with Dangerous Type
- **Affected Version:** Krayin CRM v2.2.x
- **Component:** TinyMCE Media Upload (`/admin/tinymce/upload`)

### Issue

The `/admin/tinymce/upload` endpoint accepted multipart file uploads for the TinyMCE rich text editor without validating the uploaded file's type or extension. As a result, an authenticated user could upload a malicious PHP file disguised as an image and store it in a publicly accessible directory (`/storage/tinymce/`).

By accessing the uploaded file through its generated URL, the PHP payload could be executed by the web server, resulting in authenticated remote code execution.

### Changes

This pull request strengthens the TinyMCE upload endpoint by implementing secure file upload validation.

- Added strict server-side validation for uploaded files.
- Restricted uploads to supported image MIME types and file extensions only.
- Blocked executable and dangerous file types including `.php`, `.phtml`, `.phar`, `.php3`, `.php4`, `.php5`, and similar extensions.
- Ensured uploaded files are validated before being stored.
- Preserved existing TinyMCE image upload functionality for valid image files.
- Improved the overall security of the TinyMCE upload process while maintaining backward compatibility for legitimate image uploads.

These changes mitigate the unrestricted file upload vulnerability and prevent authenticated users from uploading executable files through the TinyMCE editor.

---

## How To Test This?

1. Log in to the Krayin admin panel with a valid user account.
2. Open any page containing the TinyMCE editor (for example, Email Templates or any rich text editor).
3. Upload a valid image (`.jpg`, `.jpeg`, `.png`, `.gif`, or `.webp`) and verify that the upload succeeds.
4. Attempt to upload a PHP file (for example, `shell.php`) or rename a PHP file while spoofing its MIME type as an image.
5. Verify that the upload is rejected with an appropriate validation error.
6. Confirm that only supported image formats can be uploaded and existing TinyMCE functionality continues to work as expected.

---


