### PR TITLE
fix: escape T and emit UTC in activity .ics date-times (invalid per RFC 5545)

### DIFF
--- a/packages/Webkul/Automation/src/Helpers/Entity/Activity.php
+++ b/packages/Webkul/Automation/src/Helpers/Entity/Activity.php
@@ -290,10 +290,11 @@ class Activity extends AbstractEntity
             'BEGIN:VCALENDAR',
             'VERSION:2.0',
             'PRODID:-//Krayincrm//Krayincrm//EN',
+            'METHOD:REQUEST',
             'BEGIN:VEVENT',
             'UID:'.time().'-'.$activity->id,
-            'DTSTAMP:'.Carbon::now()->format('YmdTHis'),
-            'CREATED:'.$activity->created_at->format('YmdTHis'),
+            'DTSTAMP:'.Carbon::now()->utc()->format('Ymd\THis\Z'),
+            'CREATED:'.$activity->created_at->copy()->utc()->format('Ymd\THis\Z'),
             'SEQUENCE:1',
             'ORGANIZER;CN='.$activity->user->name.':MAILTO:'.$activity->user->email,
         ];
@@ -309,8 +310,8 @@ class Activity extends AbstractEntity
         }
 
         $content = array_merge($content, [
-            'DTSTART:'.$activity->schedule_from->format('YmdTHis'),
-            'DTEND:'.$activity->schedule_to->format('YmdTHis'),
+            'DTSTART:'.$activity->schedule_from->copy()->utc()->format('Ymd\THis\Z'),
+            'DTEND:'.$activity->schedule_to->copy()->utc()->format('Ymd\THis\Z'),
             'SUMMARY:'.$activity->title,
             'LOCATION:'.$activity->location,
             'DESCRIPTION:'.$activity->comment,


### PR DESCRIPTION
## Issue Reference

Fixes #2599

## Description

The activity notification email attaches an `invite.ics`. In
`Webkul\Automation\Helpers\Entity\Activity::getICSContent()` the four date-time
fields were built with `->format('YmdTHis')`. In PHP's `DateTime::format()`,
**`T` is the timezone-abbreviation token, not a literal**, so on a non-UTC server
(e.g. `America/Argentina/Buenos_Aires`) it renders `-03` instead of the required
`T` date/time separator:

```
DTSTART:20260728-03100000   ← invalid per RFC 5545 → Google "Cannot load event"
```

This PR:

- Escapes the `T` and a trailing literal `Z`, and emits all date-times in **UTC**
  (`->format('Ymd\THis\Z')`). `DTSTAMP`/`CREATED` are UTC-anchored;
  `schedule_from`/`schedule_to` are converted with `->utc()`. `->copy()` is used
  first so the mutable Carbon instances on the model are not altered.
- Adds `METHOD:REQUEST` so Gmail renders RSVP controls (the mail attachment mime
  is already `text/calendar`).

Resulting output is valid RFC 5545 (lines elided with `…` are unchanged by this
PR):

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Krayincrm//Krayincrm//EN
METHOD:REQUEST
BEGIN:VEVENT
…
DTSTAMP:20260723T135814Z
DTSTART:20260728T130000Z
DTEND:20260728T131500Z
…
END:VEVENT
END:VCALENDAR
```

The `Z` suffix marks UTC, so `DTSTART:20260728T130000Z` is `2026-07-28 10:00`
in `-03` shown as `13:00 UTC` — Google Calendar renders it back in the viewer's
timezone.

Single-file change; no schema, API, or behavior changes beyond the emitted `.ics`
string.

## How To Test This?

1. On a server/app with a non-UTC timezone (e.g. set
   `date_default_timezone_set('America/Argentina/Buenos_Aires')`), trigger an
   activity workflow with the **Send Email To Sales Owner** / **Send Email To
   Participants** action and open the attached `invite.ics`.
2. **Before:** the dates look like `20260728-03100000`; Google Calendar shows
   "Cannot load event". **After:** they look like `20260728T130000Z`; the event
   imports cleanly.

Quick standalone check of the formatting change (no DB required):

```php
$tz  = new DateTimeZone('America/Argentina/Buenos_Aires');
$dt  = new DateTime('2026-07-28 10:00:00', $tz);
echo $dt->format('YmdTHis')."\n";                                  // 20260728-03100000  (broken)
echo (clone $dt)->setTimezone(new DateTimeZone('UTC'))
        ->format('Ymd\THis\Z')."\n";                               // 20260728T130000Z   (valid)
```

## Documentation

- [ ] My pull request requires an update on the documentation repository.

## Branch Selection

- [x] Target Branch: 2.2

<!-- Targeting 2.2, the repo's default/active branch. -->

## Tailwind Reordering

N/A — no template/CSS changes (single PHP file).
