### PR TITLE
Fix invalid .ics: escape and fold activity text values (RFC 5545)

### DIFF
--- a/packages/Webkul/Automation/src/Helpers/Entity/Activity.php
+++ b/packages/Webkul/Automation/src/Helpers/Entity/Activity.php
@@ -301,10 +301,10 @@ class Activity extends AbstractEntity
 
         foreach ($activity->participants as $participant) {
             if ($participant->user) {
-                $content[] = 'ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.$participant->user->name.';PARTSTAT=NEEDS-ACTION:MAILTO:'.$participant->user->email;
+                $content[] = 'ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.$this->escapeICSParameter($participant->user->name).';PARTSTAT=NEEDS-ACTION:MAILTO:'.$participant->user->email;
             } else {
                 foreach (data_get($participant->person->emails, '*.value') as $email) {
-                    $content[] = 'ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.$participant->person->name.';PARTSTAT=NEEDS-ACTION:MAILTO:'.$email;
+                    $content[] = 'ATTENDEE;ROLE=REQ-PARTICIPANT;CN='.$this->escapeICSParameter($participant->person->name).';PARTSTAT=NEEDS-ACTION:MAILTO:'.$email;
                 }
             }
         }
@@ -312,13 +312,83 @@ class Activity extends AbstractEntity
         $content = array_merge($content, [
             'DTSTART:'.$activity->schedule_from->copy()->utc()->format('Ymd\THis\Z'),
             'DTEND:'.$activity->schedule_to->copy()->utc()->format('Ymd\THis\Z'),
-            'SUMMARY:'.$activity->title,
-            'LOCATION:'.$activity->location,
-            'DESCRIPTION:'.$activity->comment,
+            'SUMMARY:'.$this->escapeICSText($activity->title),
+            'LOCATION:'.$this->escapeICSText($activity->location),
+            'DESCRIPTION:'.$this->escapeICSText($activity->comment),
             'END:VEVENT',
             'END:VCALENDAR',
         ]);
 
-        return implode("\r\n", $content);
+        return implode("\r\n", array_map([$this, 'foldICSLine'], $content));
+    }
+
+    /**
+     * Escape a TEXT property value per RFC 5545 section 3.3.11.
+     *
+     * Backslash, semicolon and comma are delimiters in a TEXT value, and a
+     * line break has no literal representation at all — a raw one ends the
+     * content line, so whatever follows is read as a new property. An activity
+     * comment is free text written by a user, so it routinely contains all
+     * four: a multi-line comment whose second line happens to hold a colon
+     * ("Note: ...") yields a property named "Note", which is not a valid name,
+     * and strict parsers reject the whole calendar rather than that one line.
+     */
+    protected function escapeICSText(?string $value): string
+    {
+        return str_replace(
+            ['\\', ';', ',', "\r\n", "\n", "\r"],
+            ['\\\\', '\\;', '\\,', '\\n', '\\n', '\\n'],
+            (string) $value
+        );
+    }
+
+    /**
+     * Escape a parameter value (CN=, …) per RFC 5545 section 3.2.
+     *
+     * Parameters follow different rules from TEXT: backslash escaping does not
+     * apply, and a value carrying ':', ';' or ',' — "Sanchez, Alejandro" — has
+     * to be wrapped in double quotes instead. A double quote itself cannot be
+     * represented even inside a quoted string, and control characters cannot
+     * be represented at all, so both are dropped.
+     */
+    protected function escapeICSParameter(?string $value): string
+    {
+        $value = str_replace('"', '', preg_replace('/[\x00-\x1F\x7F]/', '', (string) $value));
+
+        return preg_match('/[:;,]/', $value)
+            ? '"'.$value.'"'
+            : $value;
+    }
+
+    /**
+     * Fold a content line to 75 octets per RFC 5545 section 3.1.
+     *
+     * Continuation lines are marked by a single leading space, which counts
+     * toward the octet budget. Splitting is done per character rather than per
+     * byte so a multi-byte UTF-8 sequence is never cut in half.
+     */
+    protected function foldICSLine(string $line): string
+    {
+        if (strlen($line) <= 75) {
+            return $line;
+        }
+
+        $lines = [];
+        $current = '';
+        $limit = 75;
+
+        foreach (mb_str_split($line, 1, 'UTF-8') as $character) {
+            if (strlen($current) + strlen($character) > $limit) {
+                $lines[] = $current;
+                $current = '';
+                $limit = 74;
+            }
+
+            $current .= $character;
+        }
+
+        $lines[] = $current;
+
+        return implode("\r\n ", $lines);
     }
 }

--- a/tests/Feature/ActivityICSContentTest.php
+++ b/tests/Feature/ActivityICSContentTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use Carbon\Carbon;
+use Webkul\Activity\Contracts\Activity as ContractsActivity;
+use Webkul\Automation\Helpers\Entity\Activity as ActivityHelper;
+
+/**
+ * Builds a stand-in activity for the .ics generator.
+ *
+ * `Webkul\Activity\Contracts\Activity` is an empty marker interface, so the
+ * generator only ever reads properties off whatever it is handed — no database
+ * round-trip is needed to exercise it.
+ */
+function icsActivity(array $overrides = []): ContractsActivity
+{
+    $participants = collect($overrides['participants'] ?? [])
+        ->map(fn ($name) => (object) [
+            'user' => (object) ['name' => $name, 'email' => 'participant@example.com'],
+        ]);
+
+    $activity = new class implements ContractsActivity
+    {
+        public $id = 1;
+
+        public $title = 'Call';
+
+        public $location = '';
+
+        public $comment = '';
+
+        public $created_at;
+
+        public $schedule_from;
+
+        public $schedule_to;
+
+        public $user;
+
+        public $participants;
+    };
+
+    $activity->created_at = Carbon::parse('2026-07-23 13:45:11', 'UTC');
+    $activity->schedule_from = Carbon::parse('2026-07-31 09:30:00', 'America/Argentina/Buenos_Aires');
+    $activity->schedule_to = Carbon::parse('2026-07-31 10:00:00', 'America/Argentina/Buenos_Aires');
+    $activity->user = (object) ['name' => 'Alejandro Sanchez', 'email' => 'organizer@example.com'];
+    $activity->participants = $participants;
+
+    foreach (array_diff_key($overrides, ['participants' => null]) as $key => $value) {
+        $activity->{$key} = $value;
+    }
+
+    return $activity;
+}
+
+/**
+ * Splits an .ics into physical lines.
+ *
+ * Deliberately breaks on a lone CR or LF as well as on CRLF. RFC 5545 delimits
+ * content lines with CRLF, but a bare line break that slipped into a value is
+ * exactly the defect worth catching, and every line-based parser — Google's
+ * included — will break on it too. Splitting on CRLF alone would swallow one
+ * inside the surrounding value and hide the bug.
+ */
+function icsPhysicalLines(string $ics): array
+{
+    return preg_split("/\r\n|\r|\n/", $ics);
+}
+
+/**
+ * Unfolds an .ics back into logical content lines the way RFC 5545 section 3.1
+ * says a parser must: a physical line starting with a space is a continuation
+ * of the previous one.
+ */
+function icsLines(string $ics): array
+{
+    $lines = [];
+
+    foreach (icsPhysicalLines($ics) as $physical) {
+        if (str_starts_with($physical, ' ') && $lines !== []) {
+            $lines[array_key_last($lines)] .= substr($physical, 1);
+
+            continue;
+        }
+
+        $lines[] = $physical;
+    }
+
+    return $lines;
+}
+
+it('keeps every content line a valid property when the comment spans lines', function () {
+    $ics = app(ActivityHelper::class)->getICSContent(icsActivity([
+        'comment' => "Mandarlo en horario comercial.\n\nTiene que dejar por escrito: USD 3.600 pago único.",
+    ]));
+
+    // A raw line break would end the content line, leaving "Tiene que dejar por
+    // escrito" to be read as a property name — which is what made Google refuse
+    // the whole file with "Cannot load event".
+    foreach (icsLines($ics) as $line) {
+        expect(explode(':', $line)[0])
+            ->toMatch('/^[A-Za-z0-9-]+(;.*)?$/', "Illegal content line: [$line]");
+    }
+});
+
+it('escapes line breaks, commas, semicolons and backslashes in text values', function () {
+    $ics = app(ActivityHelper::class)->getICSContent(icsActivity([
+        'title' => 'Chequear el mail (MAINTRAVEL); si no, insistir',
+        'comment' => "Primera linea\nSegunda, con coma\\barra",
+    ]));
+
+    $lines = icsLines($ics);
+
+    expect($lines)->toContain('SUMMARY:Chequear el mail (MAINTRAVEL)\; si no\, insistir');
+    expect($lines)->toContain('DESCRIPTION:Primera linea\nSegunda\, con coma\\\\barra');
+});
+
+it('folds long lines to 75 octets with a space-prefixed continuation', function () {
+    $ics = app(ActivityHelper::class)->getICSContent(icsActivity([
+        'comment' => str_repeat('a', 300),
+    ]));
+
+    foreach (icsPhysicalLines($ics) as $physical) {
+        expect(strlen($physical))->toBeLessThanOrEqual(75);
+    }
+
+    // Folding must be transparent: unfolding gives the value back intact.
+    expect(icsLines($ics))->toContain('DESCRIPTION:'.str_repeat('a', 300));
+});
+
+it('never splits a multi-byte character when folding', function () {
+    $ics = app(ActivityHelper::class)->getICSContent(icsActivity([
+        'comment' => str_repeat('á', 200),
+    ]));
+
+    foreach (icsPhysicalLines($ics) as $physical) {
+        expect(mb_check_encoding($physical, 'UTF-8'))->toBeTrue();
+    }
+
+    expect(icsLines($ics))->toContain('DESCRIPTION:'.str_repeat('á', 200));
+});
+
+it('quotes a participant name that carries a parameter delimiter', function () {
+    $ics = app(ActivityHelper::class)->getICSContent(icsActivity([
+        'participants' => ['Sanchez, Alejandro'],
+    ]));
+
+    expect(icsLines($ics))->toContain(
+        'ATTENDEE;ROLE=REQ-PARTICIPANT;CN="Sanchez, Alejandro";PARTSTAT=NEEDS-ACTION:MAILTO:participant@example.com'
+    );
+});
+
+it('emits schedule date-times as UTC', function () {
+    $ics = app(ActivityHelper::class)->getICSContent(icsActivity());
+
+    // 09:30 in -03 is 12:30 UTC.
+    expect(icsLines($ics))
+        ->toContain('DTSTART:20260731T123000Z')
+        ->toContain('DTEND:20260731T130000Z');
+});


### PR DESCRIPTION
## Problem

`Activity::getICSContent()` interpolates the activity title, location, comment and participant names straight into the calendar, and folds nothing. All four are free text a user typed, so the file breaks as soon as one of them contains a character the format reserves.

Line breaks are the damaging case. RFC 5545 has no literal representation for a line break inside a TEXT value — a raw one ends the content line, so whatever follows is parsed as a new property. A two-paragraph comment whose second paragraph opens with `Note: ...` yields a property named `Note`, which is not a valid name ([3.1](https://datatracker.ietf.org/doc/html/rfc5545#section-3.1) allows only alphanumerics and hyphens). Strict parsers reject the whole calendar rather than skip the line, and Google Calendar answers **"Cannot load event"**.

Observed on a real activity: a 470-character comment produced two illegal property names, and a conformant parser recovered 73 of those 470 characters.

```
DESCRIPTION:Mandarlo el lunes.
Note: no bajar el precio.          <- "Note" is read as a property name
```

Semicolons and commas are the quieter case — `SUMMARY:Chequear el mail (X); si no, insistir` is ambiguous to a parser, since both characters are list delimiters in a TEXT value.

## Fix

- **TEXT values** ([3.3.11](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.11)) — escape backslash, semicolon, comma and line breaks in `SUMMARY`, `LOCATION` and `DESCRIPTION`.
- **Parameter values** ([3.2](https://datatracker.ietf.org/doc/html/rfc5545#section-3.2)) — these follow different rules: backslash escaping does not apply, but a value carrying `:`, `;` or `,` (`Sanchez, Alejandro`) must be wrapped in double quotes. Applied to the `CN=` of `ORGANIZER` and `ATTENDEE`. A double quote cannot be represented even inside a quoted string, and control characters cannot be represented at all, so both are dropped.
- **Folding** ([3.1](https://datatracker.ietf.org/doc/html/rfc5545#section-3.1)) — fold content lines to 75 octets, splitting per character so a multi-byte UTF-8 sequence is never cut in half.

```
After:  DESCRIPTION:Mandarlo el lunes.\nNote: no bajar el precio.
```

## Tests

`tests/Feature/ActivityICSContentTest.php` covers a multi-line comment, the four escapable characters, folding width, UTF-8 boundaries, and a participant name containing a comma. Four of the six fail without this change.

One note on the test helper: it splits lines on a lone CR or LF as well as on CRLF. Splitting on CRLF alone swallows a stray line break inside the surrounding value and hides the exact defect this PR fixes — worth knowing if the helper is ever reused.

## Related

Follows #2600, which fixed the date-times in the same method. The dates were only half of what made these files unloadable.
