### PR TITLE
feat:import export custom attributes

### DIFF
--- a/packages/Webkul/Admin/src/DataGrids/Contact/PersonDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Contact/PersonDataGrid.php
@@ -3,7 +3,10 @@
 namespace Webkul\Admin\DataGrids\Contact;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeValue;
 use Webkul\Contact\Repositories\OrganizationRepository;
 use Webkul\DataGrid\DataGrid;
 use Webkul\Tag\Repositories\TagRepository;
@@ -36,6 +39,28 @@ class PersonDataGrid extends DataGrid
             ->leftJoin('person_tags', 'persons.id', '=', 'person_tags.person_id')
             ->leftJoin('tags', 'tags.id', '=', 'person_tags.tag_id')
             ->groupBy('persons.id');
+
+        /**
+         * Custom (user defined) attribute values live in the EAV `attribute_values` table, so they
+         * are pulled in as correlated sub-selects only when exporting. They are hidden from the
+         * grid display (see prepareColumns) but included in the exported file.
+         */
+        if (request()->boolean('export')) {
+            $tablePrefix = DB::getTablePrefix();
+
+            foreach ($this->getCustomAttributes() as $attribute) {
+                $valueColumn = AttributeValue::$attributeTypeFields[$attribute->type] ?? 'text_value';
+
+                $queryBuilder->addSelect(DB::raw(
+                    '(SELECT '.$tablePrefix.'attribute_values.'.$valueColumn.
+                    ' FROM '.$tablePrefix.'attribute_values'.
+                    ' WHERE '.$tablePrefix.'attribute_values.entity_id = '.$tablePrefix.'persons.id'.
+                    ' AND '.$tablePrefix.'attribute_values.attribute_id = '.(int) $attribute->id.
+                    ' AND '.$tablePrefix."attribute_values.entity_type = 'persons'".
+                    ' LIMIT 1) as '.$attribute->code
+                ));
+            }
+        }
 
         if ($userIds = bouncer()->getAuthorizedUserIds()) {
             $queryBuilder->whereIn('persons.user_id', $userIds);
@@ -126,6 +151,37 @@ class PersonDataGrid extends DataGrid
                 ],
             ],
         ]);
+
+        /**
+         * User defined attributes are hidden from the grid but included in the export so the data
+         * entered into custom fields can be exported alongside the built-in columns.
+         */
+        if (request()->boolean('export')) {
+            foreach ($this->getCustomAttributes() as $attribute) {
+                $this->addColumn([
+                    'index' => $attribute->code,
+                    'label' => $attribute->name,
+                    'type' => 'string',
+                    'searchable' => false,
+                    'sortable' => false,
+                    'filterable' => false,
+                    'visibility' => false,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Retrieve the user defined attributes for persons.
+     */
+    protected function getCustomAttributes(): Collection
+    {
+        static $attributes;
+
+        return $attributes ??= Attribute::query()
+            ->where('entity_type', 'persons')
+            ->where('is_user_defined', 1)
+            ->get();
     }
 
     /**

--- a/packages/Webkul/Admin/src/DataGrids/Lead/LeadDataGrid.php
+++ b/packages/Webkul/Admin/src/DataGrids/Lead/LeadDataGrid.php
@@ -3,7 +3,10 @@
 namespace Webkul\Admin\DataGrids\Lead;
 
 use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Webkul\Attribute\Models\Attribute;
+use Webkul\Attribute\Models\AttributeValue;
 use Webkul\Contact\Repositories\PersonRepository;
 use Webkul\Contract\Repositories\Pipeline;
 use Webkul\DataGrid\DataGrid;
@@ -81,6 +84,26 @@ class LeadDataGrid extends DataGrid
             ->leftJoin('tags', 'tags.id', '=', 'lead_tags.tag_id')
             ->groupBy('leads.id')
             ->where('leads.lead_pipeline_id', $this->pipeline->id);
+
+        /**
+         * Custom (user defined) attribute values live in the EAV `attribute_values` table, so they
+         * are pulled in as correlated sub-selects only when exporting. They are hidden from the
+         * grid display (see prepareColumns) but included in the exported file.
+         */
+        if (request()->boolean('export')) {
+            foreach ($this->getCustomAttributes() as $attribute) {
+                $valueColumn = AttributeValue::$attributeTypeFields[$attribute->type] ?? 'text_value';
+
+                $queryBuilder->addSelect(DB::raw(
+                    '(SELECT '.$tablePrefix.'attribute_values.'.$valueColumn.
+                    ' FROM '.$tablePrefix.'attribute_values'.
+                    ' WHERE '.$tablePrefix.'attribute_values.entity_id = '.$tablePrefix.'leads.id'.
+                    ' AND '.$tablePrefix.'attribute_values.attribute_id = '.(int) $attribute->id.
+                    ' AND '.$tablePrefix."attribute_values.entity_type = 'leads'".
+                    ' LIMIT 1) as '.$attribute->code
+                ));
+            }
+        }
 
         if ($userIds = bouncer()->getAuthorizedUserIds()) {
             $queryBuilder->whereIn('leads.user_id', $userIds);
@@ -283,6 +306,37 @@ class LeadDataGrid extends DataGrid
             'filterable' => true,
             'filterable_type' => 'date_range',
         ]);
+
+        /**
+         * User defined attributes are hidden from the grid but included in the export so the data
+         * entered into custom fields can be exported alongside the built-in columns.
+         */
+        if (request()->boolean('export')) {
+            foreach ($this->getCustomAttributes() as $attribute) {
+                $this->addColumn([
+                    'index' => $attribute->code,
+                    'label' => $attribute->name,
+                    'type' => 'string',
+                    'searchable' => false,
+                    'sortable' => false,
+                    'filterable' => false,
+                    'visibility' => false,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Retrieve the user defined attributes for leads.
+     */
+    protected function getCustomAttributes(): Collection
+    {
+        static $attributes;
+
+        return $attributes ??= Attribute::query()
+            ->where('entity_type', 'leads')
+            ->where('is_user_defined', 1)
+            ->get();
     }
 
     /**

--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/DataTransfer/ImportController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
 use Webkul\Admin\DataGrids\Settings\DataTransfer\ImportDataGrid;
 use Webkul\Admin\Http\Controllers\Controller;
+use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\DataTransfer\Helpers\Import;
 use Webkul\DataTransfer\Repositories\ImportRepository;
 
@@ -21,7 +22,8 @@ class ImportController extends Controller
      */
     public function __construct(
         protected ImportRepository $importRepository,
-        protected Import $importHelper
+        protected Import $importHelper,
+        protected AttributeRepository $attributeRepository
     ) {}
 
     /**
@@ -466,7 +468,45 @@ class ImportController extends Controller
     {
         $importer = config('importers.'.$type);
 
-        return Storage::download($importer['sample_path']);
+        $content = Storage::get($importer['sample_path']);
+
+        /**
+         * Append the user defined attribute codes as extra columns so the downloaded sample always
+         * reflects the custom attributes configured for the entity type. Only codes that are valid
+         * import column names (lowercase, matching the importer's column rule) are included so the
+         * generated sample remains importable.
+         */
+        $customAttributeCodes = $this->attributeRepository
+            ->findWhere(['entity_type' => $type, 'is_user_defined' => 1])
+            ->pluck('code')
+            ->filter(fn ($code) => preg_match('/^[a-z][a-z0-9_]*$/', $code))
+            ->all();
+
+        if (! empty($customAttributeCodes)) {
+            $content = $this->appendColumnsToCsv($content, $customAttributeCodes);
+        }
+
+        return response($content, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="'.basename($importer['sample_path']).'"',
+        ]);
+    }
+
+    /**
+     * Append the given columns to the header row and an empty value to every data row of a CSV.
+     */
+    protected function appendColumnsToCsv(string $content, array $columns): string
+    {
+        $lines = preg_split('/\r\n|\r|\n/', rtrim($content, "\r\n"));
+
+        $suffix = str_repeat(',', count($columns));
+
+        return collect($lines)
+            ->filter(fn ($line) => $line !== '')
+            ->map(fn ($line, $index) => $index === 0
+                ? $line.','.implode(',', $columns)
+                : $line.$suffix)
+            ->implode("\n")."\n";
     }
 
     /**

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Leads/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Leads/Importer.php
@@ -4,7 +4,9 @@ namespace Webkul\DataTransfer\Helpers\Importers\Leads;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
+use Webkul\Attribute\Models\AttributeValue;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Attribute\Repositories\AttributeValueRepository;
 use Webkul\Core\Contracts\Validations\Decimal;
@@ -85,6 +87,21 @@ class Importer extends AbstractImporter
             $attributeRepository,
             $attributeValueRepository,
         );
+
+        $this->initAttributes();
+    }
+
+    /**
+     * Append the lead attribute codes (including user defined ones) to the list of valid columns
+     * so that custom attributes can be imported alongside the built-in fields.
+     */
+    protected function initAttributes(): void
+    {
+        $attributes = $this->attributeRepository->findWhere(['entity_type' => 'leads']);
+
+        foreach ($attributes as $attribute) {
+            $this->validColumnNames[] = $attribute->code;
+        }
     }
 
     /**
@@ -394,6 +411,13 @@ class Importer extends AbstractImporter
             ];
         }
 
+        /**
+         * Nothing to link when none of the rows in this batch reference a product.
+         */
+        if (empty($leadProducts['insert'])) {
+            return;
+        }
+
         foreach ($leadProducts['insert'] as $key => $leadProduct) {
             $this->leadProductRepository->deleteWhere([
                 'lead_id' => $leadProduct['lead_id'],
@@ -445,19 +469,30 @@ class Importer extends AbstractImporter
 
         $leads = [];
 
+        $attributeValues = [];
+
         /**
          * Prepare leads for import.
          */
         foreach ($batch->data as $rowData) {
+            /**
+             * Custom (user defined) attribute values are not columns on the leads table; they are
+             * persisted separately via saveAttributeValues(). Only the native columns are written
+             * to the leads table here.
+             */
+            $native = Arr::only($rowData, $this->getEntityColumns());
+
             if (isset($rowData['id'])) {
-                $leads['update'][$rowData['id']] = Arr::except($rowData, ['product']);
+                $leads['update'][$rowData['id']] = $native;
             } else {
                 $leads['insert'][$rowData['title']] = [
-                    ...Arr::except($rowData, ['id', 'product']),
+                    ...Arr::except($native, ['id']),
                     'created_at' => $rowData['created_at'] ?? now(),
                     'updated_at' => $rowData['updated_at'] ?? now(),
                 ];
             }
+
+            $this->prepareAttributeValues($rowData, $attributeValues);
         }
 
         if (! empty($leads['update'])) {
@@ -494,7 +529,80 @@ class Importer extends AbstractImporter
             }
         }
 
+        $this->saveAttributeValues($attributeValues);
+
         return true;
+    }
+
+    /**
+     * The native columns of the leads table (custom attribute values are stored separately).
+     */
+    protected function getEntityColumns(): array
+    {
+        static $columns;
+
+        return $columns ??= Schema::getColumnListing('leads');
+    }
+
+    /**
+     * Map each row's lead attribute values (including user defined ones), keyed by lead title.
+     */
+    public function prepareAttributeValues(array $rowData, array &$attributeValues): void
+    {
+        foreach ($rowData as $code => $value) {
+            if (is_null($value)) {
+                continue;
+            }
+
+            $attribute = $this->attributeRepository->findOneWhere([
+                'code' => $code,
+                'entity_type' => 'leads',
+            ]);
+
+            if (! $attribute) {
+                continue;
+            }
+
+            $attributeTypeValues = array_fill_keys(array_values(AttributeValue::$attributeTypeFields), null);
+
+            $attributeValues[$rowData['title']][] = array_merge($attributeTypeValues, [
+                'attribute_id' => $attribute->id,
+                AttributeValue::$attributeTypeFields[$attribute->type] => $value,
+            ]);
+        }
+    }
+
+    /**
+     * Upsert the collected lead attribute values into the EAV attribute_values table.
+     */
+    public function saveAttributeValues(array $attributeValues): void
+    {
+        $leadAttributeValues = [];
+
+        foreach ($attributeValues as $title => $values) {
+            $lead = $this->leadsStorage->get($title);
+
+            if (! $lead) {
+                continue;
+            }
+
+            foreach ($values as $attribute) {
+                $attribute['entity_id'] = (int) $lead['id'];
+
+                $attribute['unique_id'] = implode('|', array_filter([
+                    $attribute['entity_id'],
+                    $attribute['attribute_id'],
+                ]));
+
+                $attribute['entity_type'] = 'leads';
+
+                $leadAttributeValues[$attribute['unique_id']] = $attribute;
+            }
+        }
+
+        if (! empty($leadAttributeValues)) {
+            $this->attributeValueRepository->upsert($leadAttributeValues, 'unique_id');
+        }
     }
 
     /**

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Persons/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Persons/Importer.php
@@ -5,6 +5,7 @@ namespace Webkul\DataTransfer\Helpers\Importers\Persons;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
 use Webkul\Attribute\Repositories\AttributeRepository;
 use Webkul\Attribute\Repositories\AttributeValueRepository;
@@ -91,6 +92,31 @@ class Importer extends AbstractImporter
             $attributeRepository,
             $attributeValueRepository,
         );
+
+        $this->initAttributes();
+    }
+
+    /**
+     * Append the person attribute codes (including user defined ones) to the list of valid columns
+     * so that custom attributes can be imported alongside the built-in fields.
+     */
+    protected function initAttributes(): void
+    {
+        $attributes = $this->attributeRepository->findWhere(['entity_type' => 'persons']);
+
+        foreach ($attributes as $attribute) {
+            $this->validColumnNames[] = $attribute->code;
+        }
+    }
+
+    /**
+     * The native columns of the persons table (custom attribute values are stored separately).
+     */
+    protected function getEntityColumns(): array
+    {
+        static $columns;
+
+        return $columns ??= Schema::getColumnListing('persons');
     }
 
     /**
@@ -151,9 +177,9 @@ class Importer extends AbstractImporter
          */
         $validator = Validator::make($rowData, [
             ...$this->getValidationRules('persons', $rowData),
-            'organization_id' => 'required|exists:organizations,id',
+            'organization_id' => 'nullable|exists:organizations,id',
             'user_id' => 'required|exists:users,id',
-            'contact_numbers' => 'required|array',
+            'contact_numbers' => 'nullable|array',
             'contact_numbers.*.value' => 'required|numeric',
             'contact_numbers.*.label' => 'required|in:home,work',
             'emails' => 'required|array',
@@ -336,11 +362,18 @@ class Importer extends AbstractImporter
 
             $rowData['unique_id'] = "{$rowData['user_id']}|{$rowData['organization_id']}|{$email}|{$contactNumber[0]['value']}";
 
+            /**
+             * Custom (user defined) attribute values are not columns on the persons table; they are
+             * persisted separately via saveAttributeValues(). Only the native columns are written
+             * to the persons table here.
+             */
+            $native = Arr::only($rowData, $this->getEntityColumns());
+
             if ($this->isEmailExist($email)) {
-                $persons['update'][$email] = $rowData;
+                $persons['update'][$email] = $native;
             } else {
                 $persons['insert'][$email] = [
-                    ...$rowData,
+                    ...$native,
                     'created_at' => $rowData['created_at'] ?? now(),
                     'updated_at' => $rowData['updated_at'] ?? now(),
                 ];
@@ -427,13 +460,10 @@ class Importer extends AbstractImporter
                 continue;
             }
 
-            $where = ['code' => $code];
-
-            if ($code === 'name') {
-                $where['entity_type'] = 'persons';
-            }
-
-            $attribute = $this->attributeRepository->findOneWhere($where);
+            $attribute = $this->attributeRepository->findOneWhere([
+                'code' => $code,
+                'entity_type' => 'persons',
+            ]);
 
             if (! $attribute) {
                 continue;

--- a/packages/Webkul/DataTransfer/src/Helpers/Importers/Products/Importer.php
+++ b/packages/Webkul/DataTransfer/src/Helpers/Importers/Products/Importer.php
@@ -84,7 +84,7 @@ class Importer extends AbstractImporter
      */
     protected function initAttributes(): void
     {
-        $this->attributes = $this->attributeRepository->all();
+        $this->attributes = $this->attributeRepository->findWhere(['entity_type' => 'products']);
 
         foreach ($this->attributes as $attribute) {
             $this->validColumnNames[] = $attribute->code;


### PR DESCRIPTION

## Description
<!--- Please describe your changes in detail. -->

### Problem

When a user creates a custom attribute (for example, a `department` field for Leads or Persons), the Data Transfer module does not handle it correctly.

- **Import:** Custom attribute columns are treated as invalid headers, and even if accepted, their values are not saved because custom attributes use the EAV (`attribute_values`) table instead of native database columns.
- **Download Sample:** The generated sample CSV does not include custom attribute columns, making users unaware that these fields can be imported.
- **Export:** Only built-in fields are exported, and custom attribute values are missing from the exported file.


### What works now

- **Custom attribute import** — Custom attributes for Leads and Persons can now be imported, and their values are saved correctly.
- **Dynamic sample file** — When custom attributes exist, downloading the sample automatically includes those columns, so users always get an up-to-date template.
- **Custom attribute export** — Exported files for Leads and Persons now include custom attribute columns and their values while keeping the on-screen grid clean.
- **Complete round trip** — Create an attribute → download the sample (with the new column) → fill in values → import → export now works end to end.
- **Leads with or without products** — Importing leads now works whether or not a product is included; product-less imports no longer fail.
- **Optional Person fields** — Persons can now be imported without an organization or contact number; email remains required, matching the normal Person form.
- **Products** — Product import and export continue to work correctly and are no longer affected by attributes from other entity types.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

1. Create custom attributes for Leads and Persons.
2. Download the sample CSV and verify the custom attribute columns are included.
3. Import data containing custom attribute values.
4. Verify the custom attribute values are saved successfully.
5. Export the Leads and Persons data and confirm the custom attribute values are included.
6. Verify Lead import works without product references.
7. Verify Person import succeeds without `organization_id` and `contact_numbers`.
8. Verify Product import only recognizes product-specific attributes.

