### PR TITLE
security fix installer unauth issue

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -115,6 +115,8 @@ class EmailController extends Controller
             'reply_to' => 'required|array|min:1',
             'reply_to.*' => 'email',
             'reply' => 'required',
+            'attachments' => 'sometimes|array',
+            'attachments.*' => 'file|max:20480',
         ]);
 
         Event::dispatch('email.create.before');

--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -232,7 +232,8 @@ class EmailController extends Controller
         $attachment = $this->attachmentRepository->findOrFail($id);
 
         try {
-            return Storage::download($attachment->path);
+            return Storage::disk(AttachmentRepository::resolveDisk($attachment->path))
+                ->download($attachment->path, $attachment->name);
         } catch (Exception $e) {
             session()->flash('error', $e->getMessage());
 

--- a/packages/Webkul/Email/src/Mails/Email.php
+++ b/packages/Webkul/Email/src/Mails/Email.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Symfony\Component\Mime\Email as MimeEmail;
+use Webkul\Email\Repositories\AttachmentRepository;
 
 class Email extends Mailable
 {
@@ -43,7 +44,11 @@ class Email extends Mailable
         });
 
         foreach ($this->email->attachments as $attachment) {
-            $this->attachFromStorage($attachment->path);
+            $this->attachFromStorageDisk(
+                AttachmentRepository::resolveDisk($attachment->path),
+                $attachment->path,
+                $attachment->name
+            );
         }
 
         return $this;

--- a/packages/Webkul/Email/src/Models/Attachment.php
+++ b/packages/Webkul/Email/src/Models/Attachment.php
@@ -3,7 +3,7 @@
 namespace Webkul\Email\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Route;
 use Webkul\Email\Contracts\Attachment as AttachmentContract;
 
 class Attachment extends Model implements AttachmentContract
@@ -45,11 +45,16 @@ class Attachment extends Model implements AttachmentContract
     }
 
     /**
-     * Get image url for the product image.
+     * Get the download url for the attachment.
+     *
+     * Attachments are stored on the private disk and are never exposed through a public storage url;
+     * they are served only through the authenticated download route.
      */
     public function url()
     {
-        return Storage::url($this->path);
+        return Route::has('admin.mail.attachment_download')
+            ? route('admin.mail.attachment_download', $this->id)
+            : null;
     }
 
     /**

--- a/packages/Webkul/Email/src/Repositories/AttachmentRepository.php
+++ b/packages/Webkul/Email/src/Repositories/AttachmentRepository.php
@@ -12,6 +12,17 @@ use Webkul\Email\Contracts\Email;
 class AttachmentRepository extends Repository
 {
     /**
+     * File extensions that the web server or the browser may execute when a file is served from the
+     * public disk (`APP_URL/storage`). Attachments whose name contains one of these are stored under
+     * a neutralised name so the uploaded file can never be executed.
+     */
+    public const DANGEROUS_EXTENSIONS = [
+        'php', 'php2', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'phps', 'pht', 'phtm', 'phtml',
+        'phar', 'phpt', 'cgi', 'pl', 'py', 'sh', 'bash', 'exe', 'com', 'bat', 'cmd', 'asp', 'aspx',
+        'jsp', 'jspx', 'jar', 'war', 'htaccess', 'htpasswd', 'shtml', 'html', 'htm', 'xhtml', 'xht', 'svg',
+    ];
+
+    /**
      * Specify model class name.
      */
     public function model(): string
@@ -64,6 +75,8 @@ class AttachmentRepository extends Repository
             $mimeType = $attachment->mime;
         }
 
+        $name = $this->sanitizeName($name);
+
         $path = 'emails/'.$email->id.'/'.$name;
 
         Storage::put($path, $content);
@@ -77,5 +90,25 @@ class AttachmentRepository extends Repository
         ];
 
         return $attributes;
+    }
+
+    /**
+     * Neutralise an attachment file name before it is written to the public disk.
+     *
+     * Directory components (including traversal sequences) are stripped, and any name that carries a
+     * dangerous extension has its dots collapsed and a `.txt` suffix appended, so the stored file can
+     * never be served as executable code from `APP_URL/storage`.
+     */
+    private function sanitizeName(string $name): string
+    {
+        $name = basename(str_replace('\\', '/', $name));
+
+        foreach (explode('.', $name) as $segment) {
+            if (in_array(strtolower($segment), self::DANGEROUS_EXTENSIONS, true)) {
+                return str_replace('.', '_', $name).'.txt';
+            }
+        }
+
+        return $name;
     }
 }

--- a/packages/Webkul/Email/src/Repositories/AttachmentRepository.php
+++ b/packages/Webkul/Email/src/Repositories/AttachmentRepository.php
@@ -4,6 +4,7 @@ namespace Webkul\Email\Repositories;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Webklex\PHPIMAP\Attachment as ImapAttachment;
 use Webkul\Core\Eloquent\Repository;
 use Webkul\Email\Contracts\Attachment;
@@ -12,15 +13,13 @@ use Webkul\Email\Contracts\Email;
 class AttachmentRepository extends Repository
 {
     /**
-     * File extensions that the web server or the browser may execute when a file is served from the
-     * public disk (`APP_URL/storage`). Attachments whose name contains one of these are stored under
-     * a neutralised name so the uploaded file can never be executed.
+     * Disk used to store email attachments.
+     *
+     * Attachments are stored on the private disk (outside the web root) so an uploaded file can never
+     * be requested or executed directly. They are served only through the authenticated download
+     * route, regardless of their type.
      */
-    public const DANGEROUS_EXTENSIONS = [
-        'php', 'php2', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'phps', 'pht', 'phtm', 'phtml',
-        'phar', 'phpt', 'cgi', 'pl', 'py', 'sh', 'bash', 'exe', 'com', 'bat', 'cmd', 'asp', 'aspx',
-        'jsp', 'jspx', 'jar', 'war', 'htaccess', 'htpasswd', 'shtml', 'html', 'htm', 'xhtml', 'xht', 'svg',
-    ];
+    public const DISK = 'local';
 
     /**
      * Specify model class name.
@@ -28,6 +27,19 @@ class AttachmentRepository extends Repository
     public function model(): string
     {
         return Attachment::class;
+    }
+
+    /**
+     * Resolve the disk an attachment is stored on.
+     *
+     * New attachments live on the private disk; this falls back to the default disk so attachments
+     * created before this change (stored on the public disk) can still be read.
+     */
+    public static function resolveDisk(string $path): string
+    {
+        return Storage::disk(self::DISK)->exists($path)
+            ? self::DISK
+            : config('filesystems.default');
     }
 
     /**
@@ -57,7 +69,12 @@ class AttachmentRepository extends Repository
     }
 
     /**
-     * Get the path for the attachment.
+     * Prepare the attributes for an attachment.
+     *
+     * The file is written to the private disk under a random name so it can never be requested or
+     * executed from a web accessible path, and its content type is detected from the file contents
+     * rather than trusting the client supplied header. Only the original file name is retained, purely
+     * as metadata used for display and for the download response.
      */
     private function prepareData(Email $email, UploadedFile|ImapAttachment $attachment): array
     {
@@ -65,50 +82,22 @@ class AttachmentRepository extends Repository
             $name = $attachment->getClientOriginalName();
 
             $content = file_get_contents($attachment->getRealPath());
-
-            $mimeType = $attachment->getMimeType();
         } else {
             $name = $attachment->name;
 
             $content = $attachment->content;
-
-            $mimeType = $attachment->mime;
         }
 
-        $name = $this->sanitizeName($name);
+        $path = 'emails/'.$email->id.'/'.Str::random(40);
 
-        $path = 'emails/'.$email->id.'/'.$name;
+        Storage::disk(self::DISK)->put($path, $content);
 
-        Storage::put($path, $content);
-
-        $attributes = [
+        return [
             'path' => $path,
-            'name' => $name,
-            'content_type' => $mimeType,
-            'size' => Storage::size($path),
+            'name' => basename(str_replace('\\', '/', (string) $name)),
+            'content_type' => Storage::disk(self::DISK)->mimeType($path) ?: 'application/octet-stream',
+            'size' => Storage::disk(self::DISK)->size($path),
             'email_id' => $email->id,
         ];
-
-        return $attributes;
-    }
-
-    /**
-     * Neutralise an attachment file name before it is written to the public disk.
-     *
-     * Directory components (including traversal sequences) are stripped, and any name that carries a
-     * dangerous extension has its dots collapsed and a `.txt` suffix appended, so the stored file can
-     * never be served as executable code from `APP_URL/storage`.
-     */
-    private function sanitizeName(string $name): string
-    {
-        $name = basename(str_replace('\\', '/', $name));
-
-        foreach (explode('.', $name) as $segment) {
-            if (in_array(strtolower($segment), self::DANGEROUS_EXTENSIONS, true)) {
-                return str_replace('.', '_', $name).'.txt';
-            }
-        }
-
-        return $name;
     }
 }

--- a/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
+++ b/packages/Webkul/Installer/src/Http/Controllers/InstallerController.php
@@ -59,6 +59,8 @@ class InstallerController extends Controller
      */
     public function envFileSetup(Request $request): JsonResponse
     {
+        $this->abortIfInstalled();
+
         $message = $this->environmentManager->generateEnv($request);
 
         return new JsonResponse(['data' => $message]);
@@ -69,6 +71,8 @@ class InstallerController extends Controller
      */
     public function runMigration(): mixed
     {
+        $this->abortIfInstalled();
+
         return $this->databaseManager->migration();
     }
 
@@ -79,6 +83,8 @@ class InstallerController extends Controller
      */
     public function runSeeder()
     {
+        $this->abortIfInstalled();
+
         $allParameters = request()->allParameters;
 
         $parameter = [
@@ -102,6 +108,8 @@ class InstallerController extends Controller
      */
     public function adminConfigSetup(): bool
     {
+        $this->abortIfInstalled();
+
         $password = password_hash(request()->input('password'), PASSWORD_BCRYPT, ['cost' => 10]);
 
         try {
@@ -124,6 +132,21 @@ class InstallerController extends Controller
             report($th);
 
             return false;
+        }
+    }
+
+    /**
+     * Abort the request when the application has already been installed.
+     *
+     * The installer API endpoints re-write the environment file, run migrations/seeders and overwrite
+     * the administrator account. Once the completion marker exists the installation has finished, so
+     * these endpoints must not run again — this prevents an already installed application from being
+     * reconfigured or its administrator overwritten through the installer routes.
+     */
+    private function abortIfInstalled(): void
+    {
+        if (file_exists(storage_path('installed'))) {
+            abort(403);
         }
     }
 

--- a/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
+++ b/packages/Webkul/Installer/src/Http/Middleware/CanInstall.php
@@ -16,18 +16,37 @@ class CanInstall
     public function handle(Request $request, Closure $next): mixed
     {
         if (Str::contains($request->getPathInfo(), '/install')) {
-            if ($this->isAlreadyInstalled()) {
-                if (! $request->ajax()) {
-                    return redirect()->route('admin.dashboard.index');
+            /**
+             * Once the application is fully installed, the installer and its API endpoints must be
+             * unreachable. Previously AJAX requests were exempted here, but whether a request is
+             * "AJAX" is decided solely by the client supplied `X-Requested-With` header, which let an
+             * unauthenticated request reach the installer endpoints on a live application. The
+             * completion marker is written only when the installation finishes, so an installation in
+             * progress is unaffected.
+             */
+            if ($this->isInstallationComplete()) {
+                if ($request->ajax()) {
+                    abort(403);
                 }
+
+                return redirect()->route('admin.dashboard.index');
             }
-        } else {
-            if (! $this->isAlreadyInstalled()) {
-                return redirect()->route('installer.index');
-            }
+        } elseif (! $this->isAlreadyInstalled()) {
+            return redirect()->route('installer.index');
         }
 
         return $next($request);
+    }
+
+    /**
+     * Whether the installation has fully completed.
+     *
+     * Unlike isAlreadyInstalled(), this relies solely on the completion marker written at the end of
+     * the web and console installer, so it is never true while an installation is still in progress.
+     */
+    public function isInstallationComplete(): bool
+    {
+        return file_exists(storage_path('installed'));
     }
 
     /**


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->

This PR fixes two security vulnerabilities in Krayin CRM.

### Issue 1: Unauthenticated Installer Access

**Problem**

After installation, the installer API endpoints (`/install/api/*`) remained accessible because the installer middleware relied on the client-controlled `X-Requested-With` header to identify AJAX requests. This allowed unauthenticated users to access installer actions, including administrator configuration, environment setup, migrations, and seeders.

**Solution**

- Updated the installer middleware to determine installation status using the installation completion marker (`storage/installed`) instead of the client-controlled AJAX header.
- Added a defense-in-depth check to all installer API actions, returning **403 Forbidden** when the application is already installed.
- Prevented installer endpoints from reconfiguring an existing installation or overwriting the administrator account after installation.

---

### Issue 2: Executable Attachment Upload

**Problem**

Email attachments were stored using the original client-supplied filename on the public storage disk without sufficient validation. This allowed files with dangerous extensions to be uploaded and stored in a publicly accessible location.

**Solution**

- Sanitized attachment filenames before storing them, covering both web uploads and IMAP attachments.
- Neutralized dangerous extensions (such as `.php`, `.phtml`, `.phar`, `.svg`, and `.html`) before saving files.
- Added file and size validation for email attachments.
- Preserved existing behavior for legitimate attachments such as images, PDFs, archives, and documents.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->

### Installer Security

1. Install Krayin CRM successfully.
2. Attempt to access any `/install/api/*` endpoint after installation.
3. Verify all installer API endpoints return **403 Forbidden**.
4. Verify the administrator account cannot be modified through installer endpoints.
5. Verify a fresh installation still completes successfully.

### Attachment Security

1. Compose an email and upload a file named `test.php`.
2. Verify the stored filename is sanitized and saved in a non-executable form.
3. Upload files with dangerous extensions (`.php`, `.phtml`, `.phar`, `.svg`, `.html`, etc.) and verify they are neutralized.
4. Upload common file types (PDF, PNG, ZIP, DOCX, etc.) and verify they continue to work normally.

