### PR TITLE
fix security issue in web form embed

### DIFF
--- a/packages/Webkul/WebForm/src/Resources/views/settings/web-forms/embed.blade.php
+++ b/packages/Webkul/WebForm/src/Resources/views/settings/web-forms/embed.blade.php
@@ -1,3 +1,10 @@
 (function() {
-    document.write(`{!! view('web_form::settings.web-forms.preview', compact('webForm'))->render() !!}`.replaceAll('$', '\$'));
+    /**
+     * The preview HTML is handed to document.write as a JSON-encoded string rather than
+     * interpolated into a template literal. Blade escapes the form's stored fields for HTML, which
+     * leaves dollar-brace sequences untouched - inert in markup, but evaluated as code by the
+     * engine once that markup sits between backticks. The replaceAll this replaces could never
+     * help, since interpolation resolves before the call runs.
+     */
+    document.write(@json(view('web_form::settings.web-forms.preview', compact('webForm'))->render()));
 })();


### PR DESCRIPTION
## Description

The public web form embed endpoint (`/web-forms/forms/{id}/form.js`) built its
response by interpolating the rendered preview HTML into a JavaScript template
literal:

```js
document.write(`{!! view(...)->render() !!}`.replaceAll('$', '\$'));
```

Blade escapes the form's stored fields for **HTML**, which correctly neutralises
tags and quotes but leaves `$`, `{` and `}` untouched — harmless in markup, but
meaningful syntax once that markup sits between backticks. A stored field could
therefore break out of the string and execute during script evaluation.

The existing `.replaceAll('$', '\$')` cannot prevent this: the literal is
resolved before the method call runs, so the substitution only ever sees the
already-evaluated result.

This affects every stored field that reaches the preview, not just the title —
`description`, `submit_button_label` and the four colour fields render into the
same response.

**Fix:** hand the rendered HTML to `document.write` as an encoded string via
`@json(...)` instead of interpolating it. The markup is then data rather than
source, and no stored value can alter the structure of the script.

Because the endpoint is public and intended for embedding on third-party sites,
the impact extended beyond the admin panel to any visitor loading a form.

## How To Test This?

1. Create a web form and set its **Title** to a value containing a
   `${ ... }` sequence — e.g. `${alert(document.domain)}`.
2. Save it and note the generated `form_id`.
3. Load `/web-forms/forms/{form_id}/form.js`, or embed it with a `<script>` tag.

**Before:** the expression is evaluated when the browser runs the script.
**After:** the response contains `document.write("` and the value is rendered as
literal text — verified against a live install, with the payload no longer
executing.

Regression coverage was written against all seven stored fields plus backtick
and tag-breakout payloads; it fails on the previous template-literal build and
passes on this one. Happy to include those tests here if preferred — they were
left out to keep this PR to the single-line fix.

