### PR TITLE
Fix security issue in the attribute file download endpoint

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/AttributeController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/AttributeController.php
@@ -238,10 +238,28 @@ class AttributeController extends Controller
      */
     public function download()
     {
-        if (! request('path')) {
-            return false;
+        $path = request('path');
+
+        /**
+         * The path arrives from the query string, so it is resolved against the attribute values
+         * that actually reference a stored file before anything is served. Handing it straight to
+         * the disk let any path on the shared storage disk be downloaded through this endpoint —
+         * import artefacts, activity attachments and configuration uploads all live alongside
+         * attribute files. The type check matters because `text_value` is shared with the text,
+         * textarea, multiselect and checkbox types, which hold no file reference.
+         */
+        if (! is_string($path) || $path === '') {
+            abort(404);
         }
 
-        return Storage::download(request('path'));
+        $attributeValue = $this->attributeValueRepository
+            ->findWhere(['text_value' => $path])
+            ->first(fn ($value) => in_array($value->attribute?->type, ['file', 'image'], true));
+
+        if (! $attributeValue) {
+            abort(404);
+        }
+
+        return Storage::download($attributeValue->text_value);
     }
 }


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
The attribute file download endpoint (`GET /admin/settings/attributes/download`) accepted the file path directly from the query string and served it from storage without checking that the path belonged to an attribute.

Because Krayin keeps every upload on one shared `public` disk, any authenticated user with attributes access could change the `path` value and download files belonging to unrelated modules — import artefacts, activity attachments, configuration uploads and editor uploads all live in the same folder.

This change resolves the requested path against the attribute values that actually reference a stored file, and serves it only when a matching file or image attribute value exists; otherwise it returns 404. It is a read-only, feature-isolation issue, not path traversal — requests outside the disk root were already blocked, and now return a clean 404 instead of a 500.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1. Sign in as a user with attributes access.
2. Place a marker file on the public disk at `storage/app/public/secretarea/hidden.txt`.
3. Open `/admin/settings/attributes/download?path=secretarea/hidden.txt`.

- **Before:** the unrelated file downloads (HTTP 200).
- **After:** HTTP 404, because no file/image attribute references that path.

A genuine attribute file still downloads as before. Also confirm these all return 404 after the fix: a real upload from another module, an empty path, a traversal attempt (`../../../.env`), and a path stored by a non-file attribute type.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.2


