### PR TITLE
Fix/tag broken access control

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Settings/TagController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Settings/TagController.php
@@ -67,6 +67,8 @@ class TagController extends Controller
     {
         $tag = $this->tagRepository->findOrFail($id);
 
+        $this->preventUnauthorizedAccess($tag->user_id);
+
         return new JsonResponse([
             'data' => $tag,
         ]);
@@ -80,6 +82,8 @@ class TagController extends Controller
         $this->validate(request(), [
             'name' => 'required|max:50|unique:tags,name,'.$id,
         ]);
+
+        $this->preventUnauthorizedAccess($this->tagRepository->findOrFail($id)->user_id);
 
         Event::dispatch('settings.tag.update.before', $id);
 
@@ -102,6 +106,8 @@ class TagController extends Controller
     public function destroy(int $id): JsonResponse
     {
         $tag = $this->tagRepository->findOrFail($id);
+
+        $this->preventUnauthorizedAccess($tag->user_id);
 
         try {
             Event::dispatch('settings.tag.delete.before', $id);
@@ -127,9 +133,16 @@ class TagController extends Controller
      */
     public function search()
     {
-        $tags = $this->tagRepository
-            ->pushCriteria(app(RequestCriteria::class))
-            ->all();
+        $tagRepository = $this->tagRepository->pushCriteria(app(RequestCriteria::class));
+
+        /**
+         * Match the tag datagrid: a user without global visibility only sees tags they own (or that
+         * their group owns). Without this, search returned every tag and leaked the ids of records
+         * hidden from the scoped listing, which the edit/update/delete handlers could then act on.
+         */
+        $tags = ($userIds = bouncer()->getAuthorizedUserIds())
+            ? $tagRepository->findWhereIn('user_id', $userIds)
+            : $tagRepository->all();
 
         return TagResource::collection($tags);
     }
@@ -139,15 +152,17 @@ class TagController extends Controller
      */
     public function massDestroy(MassDestroyRequest $massDestroyRequest): JsonResponse
     {
-        $indices = $massDestroyRequest->input('indices');
+        $tags = $this->filterAuthorizedRecords(
+            $this->tagRepository->findWhereIn('id', $massDestroyRequest->input('indices', []))
+        );
 
         try {
-            foreach ($indices as $index) {
-                Event::dispatch('settings.tag.delete.before', $index);
+            foreach ($tags as $tag) {
+                Event::dispatch('settings.tag.delete.before', $tag->id);
 
-                $this->tagRepository->delete($index);
+                $this->tagRepository->delete($tag->id);
 
-                Event::dispatch('settings.tag.delete.after', $index);
+                Event::dispatch('settings.tag.delete.after', $tag->id);
             }
 
             return new JsonResponse([


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
Tags in Krayin are owned by the user who creates them (`tags.user_id`), and the tag listing already respects that — a user without global visibility only sees their own tags (or their group's).

The direct tag endpoints did not apply the same rule. `search` returned every tag regardless of owner, and `edit`, `update`, `destroy` and `mass-destroy` acted on any tag id without an ownership check. Because the search route is reachable by anyone with tag feature access, a restricted-scope user could list tag ids that were hidden from their datagrid and then read, rename, recolour, or delete tags belonging to other users.

This change applies the same visibility scope the listing uses, reusing the base controller's existing helpers:
- `search` now returns only tags within the user's authorized scope (matching the datagrid).
- `edit`, `update` and `destroy` reject a tag outside the user's scope with a 401.
- `mass-destroy` filters the requested ids down to authorized tags before deleting.

Global-scope users are unaffected — they continue to manage all tags, consistent with every other module. Only restricted (individual/group) users are scoped.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1. Create two users who share a role but have **View Permission: Individual** — call them Alice and Bob.
2. As Alice, create a tag (Settings → Tags).
3. Sign in as Bob and open Settings → Tags. Alice's tag is not listed (this already worked before the change).
4. As Bob, hit the search endpoint `admin/settings/tags/search?query=<Alice's tag name>`.
   - **Before:** Alice's tag is returned, exposing its id.
   - **After:** Alice's tag is not returned.
5. As Bob, take Alice's tag id and try `edit`, `update`, `delete`, and `mass-destroy` on it.
   - **Before:** each action succeeds on Alice's tag.
   - **After:** each returns 401 (or is skipped for bulk delete), and Alice's tag is unchanged.
6. Confirm no regression: Bob can still fully manage his own tags, and a **View Permission: Global** user can still manage any tag.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.2

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
Not applicable — no Tailwind classes changed.

Target branch set to 2.2 (the fix branch is based there and the vuln lives there), not the template's master.


