### PR TITLE
Fix/mail linked record scope

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Mail/EmailController.php
@@ -80,19 +80,22 @@ class EmailController extends Controller
             ])
             ->findOrFail(request('id'));
 
+        /**
+         * A mail linked to a lead or person is scoped to whoever owns that record. The mailbox
+         * itself is shared, so unlinked mail stays visible to everyone with mail access; but a
+         * linked mail belonging to a lead/person outside the acting user's data scope is denied
+         * outright, rather than merely hiding its `lead_id` while still returning the subject,
+         * body, thread and attachments.
+         */
         if ($userIds = bouncer()->getAuthorizedUserIds()) {
-            $results = $this->leadRepository->findWhere([
-                ['id', '=', $email->lead_id],
-                ['user_id', 'IN', $userIds],
+            $ownerIds = array_filter([
+                $email->lead?->user_id,
+                $email->person?->user_id,
             ]);
-        } else {
-            $results = $this->leadRepository->findWhere([
-                ['id', '=', $email->lead_id],
-            ]);
-        }
 
-        if (empty($results->toArray())) {
-            unset($email->lead_id);
+            if ($ownerIds && empty(array_intersect($ownerIds, $userIds))) {
+                abort(401, trans('admin::app.errors.unauthorized'));
+            }
         }
 
         if ($route == SupportedFolderEnum::DRAFT->value) {
@@ -238,6 +241,24 @@ class EmailController extends Controller
         abort_unless(bouncer()->hasPermission('mail.view'), 401, trans('admin::app.errors.unauthorized'));
 
         $attachment = $this->attachmentRepository->findOrFail($id);
+
+        /**
+         * Bind the download to the acting user's data scope through the attachment's parent mail:
+         * an attachment on a lead/person-linked mail outside that scope is refused, so an
+         * unauthorized mail id can no longer be turned into an unauthorized file download.
+         */
+        if ($userIds = bouncer()->getAuthorizedUserIds()) {
+            $email = $attachment->email;
+
+            $ownerIds = array_filter([
+                $email?->lead?->user_id,
+                $email?->person?->user_id,
+            ]);
+
+            if ($ownerIds && empty(array_intersect($ownerIds, $userIds))) {
+                abort(401, trans('admin::app.errors.unauthorized'));
+            }
+        }
 
         try {
             return Storage::disk(AttachmentRepository::resolveDisk($attachment->path))


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail. -->
Krayin's mailbox is shared — emails have no per-user owner, and mail permissions are folder-based — so any user with mail access can see the mailbox by design. That part is not changed here.

However, an email can be linked to a lead or a person, and those records *do* have an owner and are subject to the acting user's data scope (`view_permission`). The mail view already tried to honour that: when the linked lead was outside the user's scope it hid the `lead_id`, but it still returned the email's subject, body, thread and attachments. It also never checked the linked person at all, and the attachment download only checked the broad `mail.view` permission, not the parent mail's scope.

As a result, a user restricted to self or group visibility could still read the content and download the attachments of mail linked to a lead or person they were not authorized to see.

This change scopes the two affected handlers, reusing the existing data-scope model:
- `view` now denies access (401) when the linked lead or person falls outside the user's authorized scope, instead of hiding a single field.
- Attachment download now checks the parent mail's linked lead/person against the same scope before serving the file.

Unlinked shared mail remains visible to everyone with mail access, and global-scope users continue to see everything — consistent with the rest of the CRM.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
1. Create two users who share a role but have **View Permission: Individual** — an owner and a restricted user.
2. As the owner, create a lead, then a mail linked to that lead (with an attachment).
3. Sign in as the restricted user (who does not own that lead).
4. Open the linked mail by its id (for a draft, the mail view endpoint returns its data).
   - **Before:** the subject, body, thread and attachments are returned; only the lead link is hidden.
   - **After:** the request is denied with 401.
5. Request the attachment download for that mail's attachment id.
   - **Before:** the file downloads.
   - **After:** 401.
6. Confirm no regression:
   - Unlinked shared mail is still viewable by any user with mail access.
   - The lead owner can still view their own linked mail and download its attachments.
   - A **View Permission: Global** user can still view any mail and download any attachment.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [x] Target Branch: 2.2

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->
Not applicable — no Tailwind classes changed.

Target set to 2.2, not the template's master.
