### PR TITLE
allow-customize-lead-card-information: add column settings component …

### DIFF
--- a/packages/Webkul/Admin/src/Resources/lang/ar/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ar/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'بحث',
                 ],
+                'column-settings' => [
+                    'title' => 'إعدادات الأعمدة',
+                ],
             ],
             'filters' => [
                 'select' => 'اختر',
@@ -1894,6 +1897,16 @@ return [
                         'from' => 'من',
                         'select' => 'اختر',
                         'to' => 'إلى',
+                    ],
+                    'card-settings' => [
+                        'title' => 'إعدادات البطاقة',
+                        'contact-person' => 'شخص الاتصال',
+                        'rotten-indicator' => 'مؤشر التعفن',
+                        'sales-person' => 'مندوب المبيعات',
+                        'estimated-lead-value' => 'القيمة التقديرية للعميل المحتمل',
+                        'source' => 'المصدر',
+                        'lead-type' => 'نوع العميل المحتمل',
+                        'tags' => 'العلامات',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'Search',
                 ],
+                'column-settings' => [
+                    'title' => 'Column Settings',
+                ],
             ],
             'filters' => [
                 'select' => 'Select',
@@ -1896,6 +1899,16 @@ return [
                         'from' => 'From',
                         'select' => 'Select',
                         'to' => 'To',
+                    ],
+                    'card-settings' => [
+                        'title' => 'Card Settings',
+                        'contact-person' => 'Contact Person',
+                        'rotten-indicator' => 'Rotten Indicator',
+                        'sales-person' => 'Sales Person',
+                        'estimated-lead-value' => 'Estimated Lead Value',
+                        'source' => 'Source',
+                        'lead-type' => 'Lead Type',
+                        'tags' => 'Tags',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/es/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/es/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'Buscar',
                 ],
+                'column-settings' => [
+                    'title' => 'Configuración de Columnas',
+                ],
             ],
             'filters' => [
                 'select' => 'Seleccionar',
@@ -1894,6 +1897,16 @@ return [
                         'from' => 'De',
                         'select' => 'Seleccionar',
                         'to' => 'A',
+                    ],
+                    'card-settings' => [
+                        'title' => 'Configuración de Tarjeta',
+                        'contact-person' => 'Persona de Contacto',
+                        'rotten-indicator' => 'Indicador de Podrido',
+                        'sales-person' => 'Persona de Ventas',
+                        'estimated-lead-value' => 'Valor Estimado del Lead',
+                        'source' => 'Fuente',
+                        'lead-type' => 'Tipo de Lead',
+                        'tags' => 'Etiquetas',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/fa/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/fa/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'جستجو',
                 ],
+                'column-settings' => [
+                    'title' => 'تنظیمات ستون‌ها',
+                ],
             ],
             'filters' => [
                 'select' => 'انتخاب',
@@ -1894,6 +1897,16 @@ return [
                         'from' => 'از',
                         'select' => 'انتخاب',
                         'to' => 'تا',
+                    ],
+                    'card-settings' => [
+                        'title' => 'تنظیمات کارت',
+                        'contact-person' => 'شخص تماس',
+                        'rotten-indicator' => 'نشانگر خراب شدن',
+                        'sales-person' => 'کارشناس فروش',
+                        'estimated-lead-value' => 'ارزش تخمینی سرنخ',
+                        'source' => 'منبع',
+                        'lead-type' => 'نوع سرنخ',
+                        'tags' => 'برچسب‌ها',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ja/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ja/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => '検索',
                 ],
+                'column-settings' => [
+                    'title' => '列の設定',
+                ],
             ],
             'filters' => [
                 'select' => '選択',
@@ -1896,6 +1899,16 @@ return [
                         'from' => '開始',
                         'select' => '選択',
                         'to' => '終了',
+                    ],
+                    'card-settings' => [
+                        'title' => 'カードの設定',
+                        'contact-person' => '担当者',
+                        'rotten-indicator' => '停滞インジケーター',
+                        'sales-person' => '営業担当者',
+                        'estimated-lead-value' => '見積もりリード金額',
+                        'source' => 'ソース',
+                        'lead-type' => 'リードタイプ',
+                        'tags' => 'タグ',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/ko/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/ko/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => '검색',
                 ],
+                'column-settings' => [
+                    'title' => '열 설정',
+                ],
             ],
             'filters' => [
                 'select' => '선택',
@@ -1894,6 +1897,16 @@ return [
                         'from' => '시작',
                         'select' => '선택',
                         'to' => '종료',
+                    ],
+                    'card-settings' => [
+                        'title' => '카드 설정',
+                        'contact-person' => '담당자',
+                        'rotten-indicator' => '정체 표시',
+                        'sales-person' => '영업 담당자',
+                        'estimated-lead-value' => '예상 리드 금액',
+                        'source' => '소스',
+                        'lead-type' => '리드 유형',
+                        'tags' => '태그',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/pt_BR/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'Pesquisar',
                 ],
+                'column-settings' => [
+                    'title' => 'Configurações de Colunas',
+                ],
             ],
             'filters' => [
                 'select' => 'Selecionar',
@@ -1894,6 +1897,16 @@ return [
                         'from' => 'De',
                         'select' => 'Selecionar',
                         'to' => 'Para',
+                    ],
+                    'card-settings' => [
+                        'title' => 'Configurações do Cartão',
+                        'contact-person' => 'Pessoa de Contato',
+                        'rotten-indicator' => 'Indicador de Estagnação',
+                        'sales-person' => 'Vendedor',
+                        'estimated-lead-value' => 'Valor Estimado do Negócio',
+                        'source' => 'Origem',
+                        'lead-type' => 'Tipo de Negócio',
+                        'tags' => 'Tags',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/tr/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/tr/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'Ara',
                 ],
+                'column-settings' => [
+                    'title' => 'Sütun Ayarları',
+                ],
             ],
             'filters' => [
                 'select' => 'Seç',
@@ -1894,6 +1897,16 @@ return [
                         'from' => 'Kimden',
                         'select' => 'Seç',
                         'to' => 'Kime',
+                    ],
+                    'card-settings' => [
+                        'title' => 'Kart Ayarları',
+                        'contact-person' => 'İletişim Kişisi',
+                        'rotten-indicator' => 'Çürük Göstergesi',
+                        'sales-person' => 'Satış Temsilcisi',
+                        'estimated-lead-value' => 'Tahmini Lead Değeri',
+                        'source' => 'Kaynak',
+                        'lead-type' => 'Lead Türü',
+                        'tags' => 'Etiketler',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/vi/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/vi/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => 'Tìm kiếm',
                 ],
+                'column-settings' => [
+                    'title' => 'Cài Đặt Cột',
+                ],
             ],
             'filters' => [
                 'select' => 'Chọn',
@@ -1894,6 +1897,16 @@ return [
                         'from' => 'Từ',
                         'select' => 'Chọn',
                         'to' => 'Đến',
+                    ],
+                    'card-settings' => [
+                        'title' => 'Cài Đặt Thẻ',
+                        'contact-person' => 'Người Liên Hệ',
+                        'rotten-indicator' => 'Chỉ Báo Hết Hạn',
+                        'sales-person' => 'Nhân Viên Kinh Doanh',
+                        'estimated-lead-value' => 'Giá Trị Ước Tính Khách Hàng',
+                        'source' => 'Nguồn',
+                        'lead-type' => 'Loại Khách Hàng',
+                        'tags' => 'Thẻ',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/zh_CN/app.php
@@ -275,6 +275,9 @@ return [
                 'search' => [
                     'title' => '搜索',
                 ],
+                'column-settings' => [
+                    'title' => '列设置',
+                ],
             ],
             'filters' => [
                 'select' => '选择',
@@ -1894,6 +1897,16 @@ return [
                         'from' => '从',
                         'select' => '选择',
                         'to' => '至',
+                    ],
+                    'card-settings' => [
+                        'title' => '卡片设置',
+                        'contact-person' => '联系人',
+                        'rotten-indicator' => '滞留标识',
+                        'sales-person' => '销售人员',
+                        'estimated-lead-value' => '预估线索价值',
+                        'source' => '来源',
+                        'lead-type' => '线索类型',
+                        'tags' => '标签',
                     ],
                 ],
                 'stages' => [

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/column-settings.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/column-settings.blade.php
@@ -1,0 +1,93 @@
+{!! view_render_event('admin.components.datagrid.column_settings.before') !!}
+
+<v-datagrid-column-settings
+    :columns="available.columns"
+    @update-column-visibility="updateColumnVisibility"
+>
+</v-datagrid-column-settings>
+
+{!! view_render_event('admin.components.datagrid.column_settings.after') !!}
+
+@pushOnce('scripts')
+    <script
+        type="text/x-template"
+        id="v-datagrid-column-settings-template"
+    >
+        {!! view_render_event('admin.components.datagrid.column_settings.dropdown.before') !!}
+
+        <x-admin::dropdown ::close-on-click="false">
+            <!-- Dropdown Toggler -->
+            <x-slot:toggle>
+                {!! view_render_event('admin.components.datagrid.column_settings.dropdown.toggle_button.before') !!}
+
+                <div class="icon-setting cursor-pointer rounded-md border p-2 text-lg text-gray-600 transition-all hover:border-gray-400 dark:border-gray-800 dark:text-gray-300 dark:hover:border-gray-400"></div>
+
+                {!! view_render_event('admin.components.datagrid.column_settings.dropdown.toggle_button.after') !!}
+            </x-slot>
+
+            <!-- Dropdown Content -->
+            <x-slot:content>
+                {!! view_render_event('admin.components.datagrid.column_settings.dropdown.content.before') !!}
+
+                <div class="grid w-72 max-h-[350px] gap-3 overflow-y-auto p-4">
+                    <p class="text-base font-semibold dark:text-white">
+                        @lang('admin::app.components.datagrid.toolbar.column-settings.title')
+                    </p>
+
+                    <div
+                        class="flex items-center gap-2.5"
+                        v-for="column in columns"
+                        :key="column.index"
+                    >
+                        <input
+                            type="checkbox"
+                            :id="'column-setting-' + column.index"
+                            :checked="column.visibility"
+                            class="peer hidden"
+                            @change="toggleColumn(column)"
+                        />
+
+                        <label
+                            :for="'column-setting-' + column.index"
+                            class="icon-checkbox-outline peer-checked:icon-checkbox-select cursor-pointer rounded-md text-2xl text-gray-500 peer-checked:text-brandColor"
+                        >
+                        </label>
+
+                        <label
+                            :for="'column-setting-' + column.index"
+                            class="cursor-pointer text-sm text-gray-700 dark:text-gray-300"
+                            v-html="column.label"
+                        >
+                        </label>
+                    </div>
+                </div>
+
+                {!! view_render_event('admin.components.datagrid.column_settings.dropdown.content.after') !!}
+            </x-slot>
+        </x-admin::dropdown>
+
+        {!! view_render_event('admin.components.datagrid.column_settings.dropdown.after') !!}
+    </script>
+
+    <script type="module">
+        app.component('v-datagrid-column-settings', {
+            template: '#v-datagrid-column-settings-template',
+
+            props: ['columns'],
+
+            emits: ['update-column-visibility'],
+
+            methods: {
+                /**
+                 * Emits the toggled visibility for the given column.
+                 *
+                 * @param {object} column
+                 * @returns {void}
+                 */
+                toggleColumn(column) {
+                    this.$emit('update-column-visibility', column.index, ! column.visibility);
+                },
+            },
+        });
+    </script>
+@endPushOnce

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/index.blade.php
@@ -267,6 +267,8 @@
 
                             this.available.columns = columns;
 
+                            this.applyColumnVisibilityOverrides();
+
                             this.available.actions = actions;
 
                             this.available.massActions = mass_actions;
@@ -567,6 +569,65 @@
                         this.getDatagridsStorageKey(),
                         JSON.stringify(datagrids)
                     );
+                },
+
+                //=======================================================================================
+                // Support for persisted column visibility overrides. All code is based on local storage.
+                // A datagrid without any stored overrides is unaffected; this is opt-in per `src`.
+                //=======================================================================================
+
+                /**
+                 * Returns the storage key for column visibility overrides in local storage.
+                 *
+                 * @returns {string} Storage key for column visibility overrides.
+                 */
+                getColumnVisibilityStorageKey() {
+                    return 'datagrid_column_visibility';
+                },
+
+                /**
+                 * Re-applies any column visibility overrides stored for this datagrid's `src` on top
+                 * of the columns just received from the server, so a toggled column stays hidden
+                 * across pagination, sorting and filtering.
+                 *
+                 * @returns {void}
+                 */
+                applyColumnVisibilityOverrides() {
+                    let allOverrides = JSON.parse(localStorage.getItem(this.getColumnVisibilityStorageKey())) ?? {};
+
+                    let overrides = allOverrides[this.src];
+
+                    if (! overrides) {
+                        return;
+                    }
+
+                    this.available.columns = this.available.columns.map(column => ({
+                        ...column,
+                        visibility: overrides[column.index] ?? column.visibility,
+                    }));
+                },
+
+                /**
+                 * Updates a column's visibility and persists the override in local storage, keyed by
+                 * this datagrid's `src` so it does not affect any other datagrid.
+                 *
+                 * @param {string} index - The column's index.
+                 * @param {boolean} visibility - The column's new visibility.
+                 * @returns {void}
+                 */
+                updateColumnVisibility(index, visibility) {
+                    this.available.columns = this.available.columns.map(column =>
+                        column.index === index ? { ...column, visibility } : column
+                    );
+
+                    let allOverrides = JSON.parse(localStorage.getItem(this.getColumnVisibilityStorageKey())) ?? {};
+
+                    allOverrides[this.src] = {
+                        ...(allOverrides[this.src] ?? {}),
+                        [index]: visibility,
+                    };
+
+                    localStorage.setItem(this.getColumnVisibilityStorageKey(), JSON.stringify(allOverrides));
                 },
             },
         });

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban.blade.php
@@ -131,7 +131,10 @@
 
                                     <!-- Header -->
                                     <div class="flex items-start justify-between">
-                                        <div class="flex items-center gap-1">
+                                        <div
+                                            class="flex items-center gap-1"
+                                            v-if="cardFields.contactPerson"
+                                        >
                                             <x-admin::avatar ::name="element.person ? element.person.name : 'Unknown'" />
 
                                             <div class="flex flex-col gap-0.5">
@@ -147,7 +150,7 @@
 
                                         <div
                                             class="group relative"
-                                            v-if="element.rotten_days > 0"
+                                            v-if="cardFields.rottenDays && element.rotten_days > 0"
                                         >
                                             <span class="icon-rotten cursor-default text-xl text-rose-600"></span>
 
@@ -175,46 +178,51 @@
                                     <div class="flex flex-wrap gap-1">
                                         <div
                                             class="flex items-center gap-1 rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800 dark:text-white"
-                                            v-if="element.user"
+                                            v-if="cardFields.assignedUser && element.user"
                                         >
                                             <span class="icon-settings-user text-sm"></span>
 
                                             @{{ element.user.name }}
                                         </div>
 
-                                        <div class="rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800 dark:text-white">
+                                        <div
+                                            class="rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800 dark:text-white"
+                                            v-if="cardFields.leadValue"
+                                        >
                                             @{{ element.formatted_lead_value }}
                                         </div>
 
                                         <div
                                             class="rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800 dark:text-white"
-                                            v-if="element.source"
+                                            v-if="cardFields.source && element.source"
                                         >
                                             @{{ element.source.name }}
                                         </div>
 
                                         <div
                                             class="rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800 dark:text-white"
-                                            v-if="element.type"
+                                            v-if="cardFields.type && element.type"
                                         >
                                             @{{ element.type.name }}
                                         </div>
 
                                         <!-- Tags -->
-                                        <template v-for="tag in element.tags">
-                                            {!! view_render_event('admin.leads.index.kanban.content.stage.body.card.tag.before') !!}
+                                        <template v-if="cardFields.tags">
+                                            <template v-for="tag in element.tags">
+                                                {!! view_render_event('admin.leads.index.kanban.content.stage.body.card.tag.before') !!}
 
-                                            <div
-                                                class="rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800"
-                                                :style="{
-                                                    backgroundColor: tag.color,
-                                                    color: tagTextColor[tag.color]
-                                                }"
-                                            >
-                                                @{{ tag.name }}
-                                            </div>
+                                                <div
+                                                    class="rounded-xl bg-gray-200 px-2 py-1 text-xs font-medium dark:bg-gray-800"
+                                                    :style="{
+                                                        backgroundColor: tag.color,
+                                                        color: tagTextColor[tag.color]
+                                                    }"
+                                                >
+                                                    @{{ tag.name }}
+                                                </div>
 
-                                            {!! view_render_event('admin.leads.index.kanban.content.stage.body.card.tag.after') !!}
+                                                {!! view_render_event('admin.leads.index.kanban.content.stage.body.card.tag.after') !!}
+                                            </template>
                                         </template>
                                     </div>
                                 </a>
@@ -347,6 +355,16 @@
 
                     isLoadingMore: false,
 
+                    cardFields: {
+                        contactPerson: true,
+                        rottenDays: true,
+                        assignedUser: true,
+                        leadValue: true,
+                        source: true,
+                        type: true,
+                        tags: true,
+                    },
+
                     tagTextColor: {
                         '#FEE2E2': '#DC2626',
                         '#FFEDD5': '#EA580C',
@@ -395,6 +413,8 @@
                  * @returns {void}
                  */
                 boot() {
+                    this.cardFields = this.getCardFields();
+
                     let kanbans = this.getKanbans();
 
                     if (kanbans?.length) {
@@ -809,6 +829,50 @@
                     localStorage.setItem(
                         this.getKanbansStorageKey(),
                         JSON.stringify(kanbans)
+                    );
+                },
+
+                //=======================================================================================
+                // Support for the customizable lead card fields. All code is based on local storage.
+                //=======================================================================================
+
+                /**
+                 * Returns the storage key for the lead card field's visibility in local storage.
+                 *
+                 * @returns {string} Storage key for the lead card field's visibility.
+                 */
+                getCardFieldsStorageKey() {
+                    return 'lead_kanban_card_fields';
+                },
+
+                /**
+                 * Retrieves the lead card field's visibility stored in local storage, merged with the defaults.
+                 *
+                 * @returns {object} Lead card field's visibility.
+                 */
+                getCardFields() {
+                    let storedCardFields = JSON.parse(
+                        localStorage.getItem(this.getCardFieldsStorageKey())
+                    );
+
+                    return {
+                        ...this.cardFields,
+                        ...(storedCardFields ?? {}),
+                    };
+                },
+
+                /**
+                 * Updates the lead card field's visibility and stores it in local storage.
+                 *
+                 * @param {object} fields - Lead card field's visibility.
+                 * @returns {void}
+                 */
+                updateCardFields(fields) {
+                    this.cardFields = fields;
+
+                    localStorage.setItem(
+                        this.getCardFieldsStorageKey(),
+                        JSON.stringify(fields)
                     );
                 },
             }

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban/card-settings.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban/card-settings.blade.php
@@ -1,0 +1,120 @@
+{!! view_render_event('admin.leads.index.kanban.card_settings.before') !!}
+
+<v-kanban-card-settings
+    :card-fields="cardFields"
+    @update-card-fields="updateCardFields"
+>
+</v-kanban-card-settings>
+
+{!! view_render_event('admin.leads.index.kanban.card_settings.after') !!}
+
+@pushOnce('scripts')
+    <script
+        type="text/x-template"
+        id="v-kanban-card-settings-template"
+    >
+        {!! view_render_event('admin.leads.index.kanban.card_settings.dropdown.before') !!}
+
+        <x-admin::dropdown ::close-on-click="false">
+            <!-- Dropdown Toggler -->
+            <x-slot:toggle>
+                {!! view_render_event('admin.leads.index.kanban.card_settings.dropdown.toggle_button.before') !!}
+
+                <div class="icon-setting cursor-pointer rounded-md border p-2 text-lg text-gray-600 transition-all hover:border-gray-400 dark:border-gray-800 dark:text-gray-300 dark:hover:border-gray-400"></div>
+
+                {!! view_render_event('admin.leads.index.kanban.card_settings.dropdown.toggle_button.after') !!}
+            </x-slot>
+
+            <!-- Dropdown Content -->
+            <x-slot:content>
+                {!! view_render_event('admin.leads.index.kanban.card_settings.dropdown.content.before') !!}
+
+                <div class="grid w-72 max-h-[350px] gap-3 overflow-y-auto p-4">
+                    <p class="text-base font-semibold dark:text-white">
+                        @lang('admin::app.leads.index.kanban.toolbar.card-settings.title')
+                    </p>
+
+                    <div
+                        class="flex items-center gap-2.5"
+                        v-for="field in fieldOptions"
+                    >
+                        <input
+                            type="checkbox"
+                            :id="'card-field-' + field.key"
+                            :checked="fields[field.key]"
+                            class="peer hidden"
+                            @change="toggleField(field.key)"
+                        />
+
+                        <label
+                            :for="'card-field-' + field.key"
+                            class="icon-checkbox-outline peer-checked:icon-checkbox-select cursor-pointer rounded-md text-2xl text-gray-500 peer-checked:text-brandColor"
+                        >
+                        </label>
+
+                        <label
+                            :for="'card-field-' + field.key"
+                            class="cursor-pointer text-sm text-gray-700 dark:text-gray-300"
+                            v-text="field.label"
+                        >
+                        </label>
+                    </div>
+                </div>
+
+                {!! view_render_event('admin.leads.index.kanban.card_settings.dropdown.content.after') !!}
+            </x-slot>
+        </x-admin::dropdown>
+
+        {!! view_render_event('admin.leads.index.kanban.card_settings.dropdown.after') !!}
+    </script>
+
+    <script type="module">
+        app.component('v-kanban-card-settings', {
+            template: '#v-kanban-card-settings-template',
+
+            props: ['cardFields'],
+
+            emits: ['update-card-fields'],
+
+            data() {
+                return {
+                    fields: { ...this.cardFields },
+
+                    fieldOptions: [
+                        { key: 'contactPerson', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.contact-person')' },
+                        { key: 'rottenDays', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.rotten-indicator')' },
+                        { key: 'assignedUser', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.sales-person')' },
+                        { key: 'leadValue', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.estimated-lead-value')' },
+                        { key: 'source', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.source')' },
+                        { key: 'type', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.lead-type')' },
+                        { key: 'tags', label: '@lang('admin::app.leads.index.kanban.toolbar.card-settings.tags')' },
+                    ],
+                };
+            },
+
+            watch: {
+                cardFields: {
+                    deep: true,
+
+                    handler(newFields) {
+                        this.fields = { ...newFields };
+                    },
+                },
+            },
+
+            methods: {
+                /**
+                 * Toggles the visibility of the specified card field and emits the updated fields.
+                 *
+                 * @param {string} key
+                 * @returns {void}
+                 */
+                toggleField(key) {
+                    this.fields[key] = ! this.fields[key];
+
+                    this.$emit('update-card-fields', { ...this.fields });
+                },
+            },
+        });
+    </script>
+@endPushOnce

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/kanban/toolbar.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/kanban/toolbar.blade.php
@@ -16,6 +16,13 @@
 
         {!! view_render_event('admin.leads.index.kanban.toolbar.filter.after') !!}
 
+        {!! view_render_event('admin.leads.index.kanban.toolbar.card_settings.before') !!}
+
+        <!-- Card Settings -->
+        @include('admin::leads.index.kanban.card-settings')
+
+        {!! view_render_event('admin.leads.index.kanban.toolbar.card_settings.after') !!}
+
         <div class="z-10 hidden w-full divide-y divide-gray-100 rounded bg-white shadow dark:bg-gray-900"></div>
     </div>
 

--- a/packages/Webkul/Admin/src/Resources/views/leads/index/table.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/leads/index/table.blade.php
@@ -6,6 +6,8 @@
 
     <x-slot:toolbar-right-after>
         @include('admin::leads.index.view-switcher')
+
+        <x-admin::datagrid.column-settings />
     </x-slot>
 </x-admin::datagrid>
 


### PR DESCRIPTION
…for the data grid and card settings component for Kanban leads

## Issue Reference
#2044

## Description
Added settings options that let users choose which information is displayed in the lead card.

## How To Test This?
1. Open the Leads section.
2. Navigate to the Pipeline/Kanban/List view.
3. Open settings options.
4. Verify that the available lead information options are displayed.
5. Select or deselect the required information.
6. Verify that the lead cards are updated according to the selected options.
7. Verify that the existing lead card functionality customisation is applied.

## Branch Selection
- [2.2] Target Branch: master 
